### PR TITLE
Remove unused number.of.lines assignment.

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -45,8 +45,7 @@ wrap_field_if_necessary <- function(field, value, wrap.threshold) {
 
 # Simulate what was probably the user's intended field formatting
 simulate_formatted_text <- function(field, value) {
-  text <- str_split(str_c(field, ": ", value), "\n")[[1]]
-  number.of.lines <- length(text)
+  text     <- str_split(str_c(field, ": ", value), "\n")[[1]]
   text[-1] <- str_c("    ", text[-1]) # indents all *but* the first line
   
   return(text)


### PR DESCRIPTION
This one should be a quick fix. In f17b53da44600d16360b4437cbc7388af6476e14 we streamlined the logic for `simulate_formatted_text()`, but I forgot to clear out all the old remnants:

``` r
simulate_formatted_text <- function(field, value) {
  text <- str_split(str_c(field, ": ", value), "\n")[[1]]
  number.of.lines <- length(text) # This line doesn't do anything anymore
  text[-1] <- str_c("    ", text[-1]) 

  return(text)
}
```

The proposed patch removes the unused line and improves the assignment formatting so it's easier to see what's happening with `text[-1]`:

``` r
simulate_formatted_text <- function(field, value) {
  text     <- str_split(str_c(field, ": ", value), "\n")[[1]]
  text[-1] <- str_c("    ", text[-1]) # indents all *but* the first line

  return(text)
}
```
