### PR TITLE
remove ,class-method part of name_lookup -> fix for issue #82?

### DIFF
--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -290,8 +290,11 @@ roc_process.had <- function(roclet, partita, base_path) {
         params <- rd_arguments(get_rd(pieces[2], pieces[1]))
         
       } else {
-        # Reference within this package        
-        rd_name <- names(Filter(function(x) inheritor %in% x, name_lookup))
+        # Reference within this package
+
+        # ! name_lookup contains full aliases ("name,-class-method")
+        # whereas inheritor is the name only
+        rd_name <- names(Filter(function(x) inheritor %in% sub (",.*$", "", x), name_lookup))
         
         if (length(rd_name) != 1) {
           warning("@inheritParams: can't find topic ", inheritor, 


### PR DESCRIPTION
Dear Hadley,

I encounter spurious warnings that topics are not found for S4 methods where no "normal" function of that name exists. 
I set up a minimal example package at  cbeleites / roxygenize-inheritparams .

I think the problem is the inheritParam checking in https://github.com/klutometis/roxygen/blob/s4/R/roclet-rd.R l. 257

``` R
       rd_name <- names(Filter(function(x) inheritor %in% x, name_lookup))
```

name_lookup contains the full aliases, e.g.  "mean_sd,numeric-method", but inheritor is "mean_sd" only.

``` R
       rd_name <- names(Filter(function(x) inheritor %in% sub (",.*$", "", x), name_lookup))
```

seems to fix it.
