### PR TITLE
Support for tags @newcommand and @renewcommand

### DIFF
--- a/R/rd-tag-api.R
+++ b/R/rd-tag-api.R
@@ -139,3 +139,16 @@ format.examples_tag <- function(x, ...) {
   values <- str_c(x$values, collapse = "\n")
   rd_tag(x$tag, values, space = TRUE)  
 }
+
+
+#' @S3method format newcommand_tag
+format.newcommand_tag <- function(x, ...){
+	cmds <- sapply(x$values, function(cmd){
+		# check for arguments
+		if( grepl("^((\\[[0-9]+\\])|(\\{))", cmd) ) cmd
+		else str_c("{", cmd, "}")
+	})
+	str_c("\\", x$tag, "{\\", str_trim(names(x$values)), "}", cmds, collapse="\n")
+}
+#' @S3method format renewcommand_tag
+format.renewcommand_tag <- format.newcommand_tag

--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -28,7 +28,9 @@ register.preref.parsers(parse.value,
 
 register.preref.parsers(parse.name.description,
                         'param',
-                        'method')
+                        'method',
+						'newcommand',
+						'renewcommand')
 
 register.preref.parsers(parse.name,
                         'docType')
@@ -371,6 +373,8 @@ roclet_rd_one <- function(partitum, base_path) {
       new_tag("keyword", str_split(str_trim(param), "\\s+")[[1]])
     }))
   add_tag(rd, process_had_tag(partitum, 'section', process.section))
+  add_tag(rd, process.name_description(partitum, 'newcommand'))
+  add_tag(rd, process.name_description(partitum, 'renewcommand'))
   add_tag(rd, process.examples(partitum, base_path))
 
   list(rd = rd, filename = filename)
@@ -554,3 +558,13 @@ process_had_tag <- function(partitum, tag, f = new_tag) {
 # warning("All roxygen elements must have name: ",
 #   partitum$srcref$filename, ":", partitum$srcref$lloc[1], ":",
 #   partitum$srcref$lloc[2], call. = FALSE)
+
+process.name_description <- function(partitum, tag) {
+	tags <- partitum[names(partitum) == tag]
+	if (length(tags) == 0) return()	
+	
+	desc <- str_trim(sapply(tags, "[[", "description"))
+	names(desc) <- sapply(tags, "[[", "name")
+	
+	new_tag(tag, desc)
+}

--- a/inst/tests/test-rd.R
+++ b/inst/tests/test-rd.R
@@ -266,3 +266,68 @@ test_that("deleted objects not documented", {
   expect_equal(names(out), "f2.Rd")
 })
 
+
+test_that("missing/empty name or description for name-description pairs produces errors/warnings", {
+	
+	clear_caches()
+	tags <- c('param', 'method', 'newcommand', 'renewcommand')
+	lapply(tags, function(key){
+		# missing name
+		expect_error(roc_proc_text(roc, sprintf("#' @name a\n#' @%s\nNULL", key))
+				, sprintf("@%s requires a name and description", key))
+		# empty name
+		expect_error(roc_proc_text(roc, sprintf("#' @name a\n#' @%s    \nNULL", key))
+				, sprintf("@%s requires a name and description", key))
+		
+		# missing description
+		expect_that(roc_proc_text(roc, sprintf("#' @name a\n#' @%s toto\nNULL", key))
+				, gives_warning(sprintf("@%s `toto` has an empty description", key)))
+		# empty description
+		expect_that(roc_proc_text(roc, sprintf("#' @name a\n#' @%s toto   \nNULL", key))
+				, gives_warning(sprintf("@%s `toto` has an empty description", key)))
+	})
+		
+})
+
+test_that("tags @newcommand and @renewcommand are correctly extracted and formated", {
+			
+	clear_caches()
+	out <- roc_proc_text(roc, "
+		#' @newcommand noarg noarg:\\alpha
+		#' @newcommand noarg2 {noarg2:\\alpha}
+		#' @newcommand cmd [1]{cmd:\\texttt{#1}}
+		#' @newcommand cmd2 [1]{cmd2:\\texttt{#1}}
+		#'
+		#' @renewcommand recmdNoarg recmdNoarg:\\beta
+		#' @renewcommand recmdNoarg2 {recmdNoarg2:\\beta}
+		#' @renewcommand recmd [1]{recmd:\\textit{#1}}
+		#' @name a
+		NULL")[[1]]
+
+	# extraction
+	cmd <- get_tag(out, "newcommand")$values
+	expect_equivalent(cmd['noarg'], "noarg:\\alpha")
+	expect_equivalent(cmd['noarg2'], "{noarg2:\\alpha}")
+	expect_equivalent(cmd['cmd'], "[1]{cmd:\\texttt{#1}}")
+	expect_equivalent(cmd['cmd2'], "[1]{cmd2:\\texttt{#1}}")
+	recmd <- get_tag(out, "renewcommand")$values
+	expect_equivalent(recmd['recmdNoarg'], "recmdNoarg:\\beta")
+	expect_equivalent(recmd['recmdNoarg2'], "{recmdNoarg2:\\beta}")
+	expect_equivalent(recmd['recmd'], "[1]{recmd:\\textit{#1}}")
+	
+	# output
+	expect_equal(strsplit(format(get_tag(out, "newcommand")), "\n")[[1]]
+	, c("\\newcommand{\\noarg}{noarg:\\alpha}"
+		,"\\newcommand{\\noarg2}{noarg2:\\alpha}"
+		, "\\newcommand{\\cmd}[1]{cmd:\\texttt{#1}}"
+		, "\\newcommand{\\cmd2}[1]{cmd2:\\texttt{#1}}"
+		)
+		, info="tag newcommand are correctly formated")
+	expect_equal(strsplit(format(get_tag(out, "renewcommand")), "\n")[[1]]
+		, c("\\renewcommand{\\recmdNoarg}{recmdNoarg:\\beta}"
+				,"\\renewcommand{\\recmdNoarg2}{recmdNoarg2:\\beta}"
+				, "\\renewcommand{\\recmd}[1]{recmd:\\textit{#1}}"
+		)
+		, info="tag renewcommand are correctly formated"
+		)		
+})


### PR DESCRIPTION
Adds support for tags `@newcommand` and `@renewcommand` corresponding to the Rd commands `\newcommand` and `\renewcommand`, which allow to define new Rd commands to be used in the Rd file they are defined.
