### PR TITLE
Comply with R's error reporting conventions

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -3,7 +3,7 @@
 }
 
 # Given argument list, produce usage string for it.
-# 
+#
 # Adapted from \code{\link{prompt}}.
 #
 # @param f function, or name of function, as string
@@ -17,13 +17,13 @@ usage <- function(args) {
     text <- deparse(arg, backtick = TRUE, width.cutoff = 500L)
     text <- str_replace_all(text, fixed("%"), "\\%")
     text <- str_replace_all(text, fixed(" "), "\u{A0}")
-    Encoding(text) <- "UTF-8"    
-    
+    Encoding(text) <- "UTF-8"
+
     str_c("\u{A0}=\u{A0}", paste(text, collapse = "\n"))
   }
 
   arg_values <- vapply(args, arg_to_text, character(1))
-  
+
   paste(names(args), arg_values, collapse = ", ", sep = "")
 }
 
@@ -89,5 +89,5 @@ roxygen_warning <- function(..., srcref = NULL) {
 
 srcref_location <- function(srcref = NULL) {
   if (is.null(srcref)) return()
-  str_c(" in block ", basename(srcref$filename), ":", srcref$lloc[1])
+  str_c(" in block \n  ", srcref$filename, ":", srcref$lloc[1],":1:")
 }


### PR DESCRIPTION
R usually reports errors with a full path on a separate line. Something like

```
  Error in source(file = "c:/spinus/works/pbm/protoClasses.R") :
    c:/spinus/works/pbm/protoClasses.R:374:31: unexpected ', '
    373:                                  .initCells(dots,  .self)
```

It is good to comply with this convention, as some IDEs (for example ESS) can
track this errors and navigate directly to the error location.

With this commit errors in roxygen blocks are reported as:

```
Error: examples requires a value in block 
  /home/vitoshka/Dropbox/works/protoClasses.roxygen/R/funcs.R:56:1:

```

(also remove trailing whitespaces in utils.R)
