### PR TITLE
fixed \dontrun escape problem

### DIFF
--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -509,7 +509,10 @@ process.examples <- function(partitum, base_path) {
     paths <- file.path(base_path, str_trim(paths))
     examples <- unlist(lapply(paths, readLines))
     examples <- gsub("([%\\])", "\\\\\\1", examples)
-
+    
+    #undo escape for dontrun tag
+    examples <- gsub("\\\\dontrun", "\\dontrun", examples, fixed=TRUE)
+    
     out <- c(out, new_tag("examples", examples))
   }
   out


### PR DESCRIPTION
When an external example script contains a `\dontrun{}` snippet, the backslash should not be escaped. 

This is a one-line fix.
