### PR TITLE
Sort tags in .Rd files in "C" locale

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,8 +7,8 @@
 
 * Now imports `digest` package instead of depending on it.
 
-* Always use C locale when sorting `NAMESPACE` file. This ensures a consistent
-  ordering across systems.
+* Always use C locale when sorting `NAMESPACE` file or tags in `.Rd` files.
+  This ensures a consistent ordering across systems.  (Fixes #127)
 
 roxygen2 2.2.2
 --------------

--- a/R/rd-tag-api.R
+++ b/R/rd-tag-api.R
@@ -46,7 +46,7 @@ merge.rd_tag <- function(x, y, ...) {
 #' @S3method format keyword_tag
 #' @S3method format alias_tag
 format_rd <- function(x, ...) {
-  vapply(sort(unique(x$values)), rd_tag, tag = x$tag,
+  vapply(with_locale("C", sort(unique(x$values))), rd_tag, tag = x$tag,
     FUN.VALUE = character(1), USE.NAMES = FALSE)
 }
 format.keyword_tag <- format_rd

--- a/R/util-locale.R
+++ b/R/util-locale.R
@@ -1,7 +1,6 @@
 with_locale <- function(locale, code) {
   cur <- Sys.getlocale(category = "LC_COLLATE")
   Sys.setlocale(category = "LC_COLLATE", locale = locale)
-  res <- force(code)
-  Sys.setlocale(category = "LC_COLLATE", locale = cur)
-  res
+  on.exit(Sys.setlocale(category = "LC_COLLATE", locale = cur))
+  force(code)
 }


### PR DESCRIPTION
Fixes #127. Also includes a safer variant of `with_locale()`.
