### PR TITLE
use full names of arguments

### DIFF
--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -225,7 +225,7 @@ rd_roclet <- function() {
 roc_process.had <- function(roclet, partita, base_path) {
   # Remove srcrefs with no attached roxygen comments
   partita <- Filter(function(x) length(x) > 1, partita)
-  templates <- dir(file.path(base_path, "max-roxygen"), full = TRUE)
+  templates <- dir(file.path(base_path, "max-roxygen"), full.names = TRUE)
   template_hash <- digest(lapply(templates, readLines))
   
   topics <- list()

--- a/R/roxygenize.R
+++ b/R/roxygenize.R
@@ -88,7 +88,7 @@ copy.dir <- function(source,
   if (unlink.target)
     unlink(target, recursive=TRUE)
   files <- list.files(source,
-                      full.name=TRUE,
+                      full.names=TRUE,
                       recursive=TRUE,
                       all.files=TRUE)
   for (source.file in files) {

--- a/R/template.R
+++ b/R/template.R
@@ -13,7 +13,7 @@ template_find <- function(base_path, template_name) {
 
 #' @importFrom brew brew
 template_eval <- function(template_path, vars) {
-  capture.output(brew(template_path, env = vars))
+  capture.output(brew(template_path, envir = vars))
 }
 
 process_templates <- function(partitum, base_path) {


### PR DESCRIPTION
to avoid the "partial match" warning in R CMD check
