### PR TITLE
Small change to Reference Class example in Rd vignette

### DIFF
--- a/vignettes/rd.Rmd
+++ b/vignettes/rd.Rmd
@@ -158,12 +158,12 @@ Functions are the mostly commonly documented objects. Most functions use three t
     must work without errors as it is run automatically as part of `R CMD
     check`.
 
-    However for the purpose of illustration, it's often useful to include code
+    For the purpose of illustration, it's often useful to include code
     that causes an error. `\dontrun{}` allows you to include code in the
-    example that is never used. There are two other special commands.
-    `\dontshow{}` is run, but not shown in the help page: this can
+    example that is never use. There are two other special commands
+    Code `\dontshow{}` is run, but not shown in the help page: this can
     be useful for informal tests. `\donttest{}` is run in examples,
-    but not run automatically in `R CMD check`. This is useful if you
+    but not run automatically but `R CMD check`. This is useful if you
     have examples that take a long time to run. The options are summarised
     below.
 
@@ -171,7 +171,7 @@ Functions are the mostly commonly documented objects. Most functions use three t
     ------------ | --------- | ------ | -----------
     `\dontrun{}` |           | x      |
     `\dontshow{}`| x         |        | x
-    `\donttest{}`| x         | x      |
+    `\donttest{}`| x         | x      | x
 
     Instead of including examples directly in the documentation, you can
     put them in separate files and use `@example path/relative/to/packge/root`
@@ -264,7 +264,7 @@ Use either `@rdname` or `@describeIn` to control where method documentation goes
 RC is different to S3 and S4 because methods are associated with classes, not generics. RC also has a special convention for documenting methods: the docstring. This makes documenting RC simpler than S4 because you only need one roxygen block per class.
 
 ```{r}
-#' An S4 class to represent a bank account.
+#' A Reference Class to represent a bank account.
 #'
 #' @field balance A length-one numeric vector
 Account <- setRefClass("Account",


### PR DESCRIPTION
I can't get the description for `balance()` to work, but that's a slightly different issue that I'll create an issue for.
