### PR TITLE
Filter folders in "man"

### DIFF
--- a/R/safety.R
+++ b/R/safety.R
@@ -1,6 +1,6 @@
 first_time <- function(path) {
   generated <- dir(file.path(path, "man"), full.names = TRUE)
-  generated <- generated[file.info(generated)$isdir]
+  generated <- generated[!file.info(generated)$isdir]
 
   namespace <- file.path(path, "NAMESPACE")
   if (file.exists(namespace)) {


### PR DESCRIPTION
Roxygen will try to access folders as if they were ".Rd" files in the "man" directory (at least in Windows).

See the following thread for more details:
https://groups.google.com/forum/#!topic/rdevtools/QIsmPk_YL_U
