### PR TITLE
Add a C++ preparser for Roxygen blocks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^\.travis\.yml$
 ^\NEWS\.md$
 ^cran-comments\.md$
+^roxygen.pro$
+^roxygen.pro.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.so
 .Rproj.user
 /.Rhistory
+
+## Qt Creator
+*.pro
+*.pro.user

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,6 +9,14 @@ leadingSpaces <- function(lines) {
     .Call('roxygen2_leadingSpaces', PACKAGE = 'roxygen2', lines)
 }
 
+preparse_block <- function(x) {
+    .Call('roxygen2_preparse_block', PACKAGE = 'roxygen2', x)
+}
+
+preparse_file <- function(filePath) {
+    .Call('roxygen2_preparse_file', PACKAGE = 'roxygen2', filePath)
+}
+
 splitByWhitespace <- function(string) {
     .Call('roxygen2_splitByWhitespace', PACKAGE = 'roxygen2', string)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -35,6 +35,36 @@ BEGIN_RCPP
     return __sexp_result;
 END_RCPP
 }
+// preparse_block
+List preparse_block(std::string x);
+RcppExport SEXP roxygen2_preparse_block(SEXP xSEXP) {
+BEGIN_RCPP
+    SEXP __sexp_result;
+    {
+        Rcpp::RNGScope __rngScope;
+        Rcpp::traits::input_parameter< std::string >::type x(xSEXP );
+        List __result = preparse_block(x);
+        PROTECT(__sexp_result = Rcpp::wrap(__result));
+    }
+    UNPROTECT(1);
+    return __sexp_result;
+END_RCPP
+}
+// preparse_file
+List preparse_file(std::string filePath);
+RcppExport SEXP roxygen2_preparse_file(SEXP filePathSEXP) {
+BEGIN_RCPP
+    SEXP __sexp_result;
+    {
+        Rcpp::RNGScope __rngScope;
+        Rcpp::traits::input_parameter< std::string >::type filePath(filePathSEXP );
+        List __result = preparse_file(filePath);
+        PROTECT(__sexp_result = Rcpp::wrap(__result));
+    }
+    UNPROTECT(1);
+    return __sexp_result;
+END_RCPP
+}
 // splitByWhitespace
 std::vector<std::string> splitByWhitespace(std::string string);
 RcppExport SEXP roxygen2_splitByWhitespace(SEXP stringSEXP) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,346 @@
+#include "roxygen.h"
+using namespace Rcpp;
+
+namespace roxygen {
+
+class BlockParser
+{
+
+public:
+
+  explicit BlockParser(std::string const& input)
+  {
+    stripRoxygenDelimitersAndStore(input);
+    filePath_ = std::string();
+    row_ = 0;
+  }
+
+  BlockParser(std::string const& input,
+                     std::string const& filePath,
+                     int row)
+  {
+    stripRoxygenDelimitersAndStore(input);
+    filePath_ = filePath;
+    row_ = row;
+  }
+
+  List parse()
+  {
+
+    ListBuilder outputBuilder;
+
+    // The initial row for this block
+    int startRow = row_;
+
+    // Find the location of the first opening tag -- everything
+    // before that is wrapped into the 'introduction'
+    int firstTagIndex = findFirstTagIndex();
+    int index = firstTagIndex;
+
+    LOG("First tag found at index '" << index << "'");
+
+    if (firstTagIndex > 0)
+    {
+      LOG("Filling introduction:");
+      LOG(substring(content_, 0, firstTagIndex));
+
+      // NOTE: 'add' protects any added SEXP
+      CharacterVector introduction = substring(content_, 0, firstTagIndex);
+      addFileName(introduction, filePath_);
+      addRow(introduction, startRow + 1);
+      outputBuilder.add("introduction", introduction);
+      LOG("Introduction ended at row: '" << row_ << "'");
+    }
+
+    while (index < n_)
+    {
+      // Lines should start with an '@'
+      PARSE_CHECK('@', content_[index]);
+      ++index;
+      int tagStart = index;
+
+      // Move over alphabetical characters (these constitute the tag)
+      while (isAlpha(content_[index]))
+        ++index;
+
+      int tagEnd = index;
+      std::string tag = substring(content_, tagStart, tagEnd);
+      LOG("Handling tag '" << tag << "'");
+
+      // NOTE: 'add' protects any added SEXP
+      LOG("row_ before 'getRoxygenTagValue': '" << row_ << "'");
+      CharacterVector tagValue = wrap(getRoxygenTagValue(index));
+      LOG("row_ after 'getRoxygenTagValue': '" << row_ << "'");
+
+      addFileName(tagValue, filePath_);
+      addRow(tagValue, row_ + 1);
+      outputBuilder.add(tag, tagValue);
+
+      index = findNextTagOrEnd(index, &row_);
+
+    }
+
+    List output(outputBuilder);
+    output.attr("delimiter") = roxyDelim_;
+    return output;
+
+  }
+
+private:
+
+  template <typename T>
+  void addFileName(T const& x, std::string const& fileName)
+  {
+    Shield<SEXP> wrapped(wrap(fileName));
+    Rf_setAttrib(x, Rf_install("file"), wrapped);
+  }
+
+  template <typename T>
+  void addRow(T const& x, int row)
+  {
+    Shield<SEXP> wrapped(wrap(row));
+    Rf_setAttrib(x, Rf_install("row"), wrapped);
+  }
+
+  std::string getRoxygenDelimiter(std::string const& input)
+  {
+    int index = 0;
+    PARSE_CHECK('#', input[index]);
+    while (input[index] == '#')
+    {
+      ++index;
+    }
+
+    PARSE_CHECK('\'', input[index]);
+    ++index;
+
+    while (isWhitespace(input[index]))
+    {
+      ++index;
+    }
+    return substring(input, 0, index);
+  }
+
+  void stripRoxygenDelimitersAndStore(std::string const& input)
+  {
+    // Store the roxygen delimiter format
+    roxyDelim_ = getRoxygenDelimiter(input);
+
+    // Strip out roxygen delimiters
+    int n = input.length();
+    content_.reserve(n);
+
+    // Initialize some indices
+    int start = 0;
+    int end = 0;
+
+    // Loop over all lines and strip
+    while (true)
+    {
+      // Move 'start' over the roxygen delimiter
+      PARSE_CHECK('#', input[start]);
+      while (input[start] == '#')
+      {
+        ++start;
+      }
+
+      // Move over the following '\''
+      PARSE_CHECK('\'', input[start]);
+      ++start;
+
+      // Move over whitespace (not newlines)
+      while (input[start] == ' ' ||
+             input[start] == '\t' ||
+             input[start] == '\v')
+      {
+        ++start;
+      }
+
+      // We now have the start -- put end at the following newline
+      end = input.find('\n', start);
+      if (end == std::string::npos || end == n - 1)
+      {
+        LOG("Adding: '" << substring(input, start, n) << "' as final string");
+        content_.append(substring(input, start, n));
+        break;
+      }
+      else
+      {
+        LOG("Adding: '" << substring(input, start, end) << "'");
+        content_.append(substring(input, start, end + 1));
+      }
+
+      // update start, end state
+      start = end + 1;
+      end = start;
+    }
+    n_ = content_.length();
+    LOG("Content after strip:\n");
+    LOG(content_);
+  }
+
+  int findNextTagOrEnd(int index)
+  {
+
+    do {
+      if (content_[index] == '\n')
+      {
+        if (content_[index + 1] == '@')
+        {
+          break;
+        }
+      }
+    } while (++index < n_ - 1);
+
+    return index + 1;
+  }
+
+  int findNextTagOrEnd(int index, int* row)
+  {
+
+    do {
+      if (content_[index] == '\n')
+      {
+        ++*row;
+        if (content_[index + 1] == '@')
+        {
+          break;
+        }
+      }
+    } while (++index < n_ - 1);
+
+    return index + 1;
+  }
+
+
+  // Get the parameter value
+  // index represents the location just past e.g. '@foo'
+  std::string getRoxygenTagValue(int start)
+  {
+    int end = findNextTagOrEnd(start);
+
+    // Move backwards over newlines and whitespace to trim
+    while (content_[end - 1] == ' ' ||
+           content_[end - 1] == '\t' ||
+           content_[end - 1] == '\n')
+      --end;
+
+    // If we moved back to / before start, just return empty string
+    if (end <= start)
+    {
+      return std::string();
+    }
+
+    // Similarily, for the start
+    fwdOverWhitespace(content_, &start);
+
+    if (end <= start)
+    {
+      return std::string();
+    }
+
+    return substring(content_, start, end);
+  }
+
+  int findFirstTagIndex()
+  {
+    // If the first character is a '@', we already have Roxygen params
+    if (content_[0] == '@')
+      return 0;
+
+    // Find the first '@' starting a new line
+    int index = 0;
+    do {
+      if (content_[index] == '\n')
+      {
+        ++row_;
+        if (content_[index + 1] == '@')
+        {
+          break;
+        }
+      }
+    } while (++index < n_ - 1);
+
+    return index + 1;
+  }
+
+  std::string content_;
+  std::string filePath_;
+  std::string roxyDelim_;
+  int row_;
+  int n_;
+
+};
+
+
+class FileParser
+{
+
+public:
+
+  static List parse(std::string const& filePath)
+  {
+
+    // The file connection
+    std::ifstream conn(filePath.c_str());
+
+    // Memory for the blocks
+    std::vector<List> allBlocks;
+
+    // Memory for the current block we're attempting to parse
+    std::string thisBlockString;
+    thisBlockString.reserve(1024);
+
+    // The line we just read in
+    std::string line;
+
+    // The number of lines read in (so we can track the row)
+    int blockStartRow = 0;
+    int currentRow = 0;
+
+    while (std::getline(conn, line))
+    {
+      if (isRoxygenDelimited(line))
+      {
+        thisBlockString.append(line).append("\n");
+      }
+      else
+      {
+        if (thisBlockString.length() > 0)
+        {
+          allBlocks.push_back(
+                BlockParser(
+                  thisBlockString,
+                  filePath,
+                  blockStartRow
+                ).parse()
+          );
+        }
+
+        thisBlockString.clear();
+        thisBlockString.reserve(1024);
+        blockStartRow = currentRow + 1;
+      }
+      ++currentRow;
+    }
+
+    List output = wrap(allBlocks);
+    return output;
+
+  }
+
+};
+
+} // namespace parser
+
+// [[Rcpp::export]]
+List preparse_block(std::string x)
+{
+  return roxygen::BlockParser(x).parse();
+}
+
+// [[Rcpp::export]]
+List preparse_file(std::string filePath)
+{
+  return roxygen::FileParser::parse(filePath);
+}

--- a/src/roxygen.h
+++ b/src/roxygen.h
@@ -1,0 +1,174 @@
+#ifndef ROXYGEN_H
+#define ROXYGEN_H
+
+#include <fstream>
+#include <Rcpp.h>
+
+// Debugging functions -- set DEBUG_LEVEL to 0 to turn off
+#define DEBUG_LEVEL 0
+
+#if defined(DEBUG_LEVEL) && DEBUG_LEVEL > 0
+
+// Utility macro functions
+#define ROXYGEN_STOP(EXPRESSION) {                                             \
+  std::stringstream SS__;                                                      \
+  SS__ << EXPRESSION;                                                          \
+  ::Rcpp::stop(SS__.str());                                                    \
+}
+
+#define LOG(EXPRESSION) std::cout << EXPRESSION << std::endl
+
+#define PARSE_ERROR(EXPECTED, GOT) {                                           \
+  std::stringstream STRINGSTREAM__;                                            \
+  STRINGSTREAM__ << "Parse error: expected '"                                  \
+                 << EXPECTED                                                   \
+                 << "', got '"                                                 \
+                 << GOT                                                        \
+                 << "'"                                                        \
+                 << " (line " << __LINE__ << ")";                              \
+  stop(STRINGSTREAM__.str());                                                  \
+}
+
+#define PARSE_CHECK(EXPECTED, GOT) {                                           \
+  if (EXPECTED != GOT) {                                                       \
+    PARSE_ERROR(EXPECTED, GOT)                                                 \
+  }                                                                            \
+}
+
+#else
+
+#define LOG(EXPRESSION)
+#define PARSE_ERROR(EXPECTED, GOT)
+#define PARSE_CHECK(EXPECTED, GOT)
+
+#endif
+
+// Utility functions
+
+namespace roxygen {
+
+bool isRoxygenDelimited(std::string const& line)
+{
+  if (line[0] != '#') return false;
+  int index = 0;
+  while (line[index] == '#') ++index;
+  return line[index] == '\'';
+}
+
+template <typename T>
+inline bool contains(std::vector<T> const& self, T const& other)
+{
+  return std::find(self.begin(), self.end(), other) != self.end();
+}
+
+std::vector<char> initWhitespaceChars()
+{
+  std::vector<char> kWhitespaceChars;
+  kWhitespaceChars.push_back('\v');
+  kWhitespaceChars.push_back('\n');
+  kWhitespaceChars.push_back('\r');
+  kWhitespaceChars.push_back('\t');
+  kWhitespaceChars.push_back(' ');
+  return kWhitespaceChars;
+}
+
+static const std::vector<char> kWhitespaceChars = initWhitespaceChars();
+
+inline bool isAlpha(char x)
+{
+  return (x >= 'A' && x <= 'Z') || (x >= 'a' && x <= 'z');
+}
+
+inline bool isNumeric(char x)
+{
+  return x >= '0' && x <= '9';
+}
+
+inline bool isAlphaNumeric(char x)
+{
+  return isAlpha(x) || isNumeric(x);
+}
+
+inline bool isWhitespace(char x)
+{
+  return contains(kWhitespaceChars, x);
+}
+
+inline std::string substring(std::string const& self, int from, int to)
+{
+#if DEBUG_LEVEL > 0
+  if (from > to)
+  {
+    ROXYGEN_STOP("substring error: 'from' > 'to' (" << from << ", " << to << ")");
+  }
+#endif
+  return self.substr(from, to - from);
+}
+
+inline void fwdOverWhitespace(std::string const& content, int* index)
+{
+  while (contains(kWhitespaceChars, content[*index]))
+  {
+    ++*index;
+  }
+}
+
+inline void bwdOverWhitespace(std::string const& content, int* index)
+{
+  while (contains(kWhitespaceChars, content[*index - 1]))
+  {
+    --*index;
+  }
+}
+
+class ListBuilder {
+
+public:
+
+  ListBuilder() {};
+  ~ListBuilder() {};
+
+  inline ListBuilder& add(std::string const& name, SEXP x)
+  {
+    names_.push_back(name);
+    elements_.push_back(PROTECT(x));
+    return *this;
+  }
+
+  inline operator Rcpp::List() const
+  {
+    int n = elements_.size();
+    Rcpp::List result(n);
+    for (int i = 0; i < n; ++i) {
+      result[i] = elements_[i];
+    }
+    result.attr("names") = Rcpp::wrap(names_);
+    UNPROTECT(n);
+    return result;
+  }
+
+  inline operator Rcpp::DataFrame() const
+  {
+    int n = elements_.size();
+    Rcpp::List result = static_cast<Rcpp::List>(*this);
+    result.attr("class") = "data.frame";
+    result.attr("row.names") =
+        Rcpp::IntegerVector::create(NA_INTEGER, XLENGTH(elements_[0]));
+    UNPROTECT(n);
+    return result;
+  }
+
+private:
+
+  std::vector<std::string> names_;
+  std::vector<SEXP> elements_;
+
+  // Prevent copying
+  ListBuilder(ListBuilder const&);
+  ListBuilder& operator=(ListBuilder const&);
+
+};
+
+} // end namespace roxygen
+
+#endif // ROXYGEN_H

--- a/tests/testthat/roxygen-block-1.R
+++ b/tests/testthat/roxygen-block-1.R
@@ -1,0 +1,13 @@
+##' Title
+##'
+##' Description
+##'
+##' Details
+##'
+##' @param x,y,z Descriptions for x, y, z
+##' @param a Description of a
+##' @param b
+##'   Description of b
+##' @section Important:
+##' Don't run with scissors!
+##' @export

--- a/tests/testthat/roxygen-block-2.R
+++ b/tests/testthat/roxygen-block-2.R
@@ -1,0 +1,10 @@
+#' The length of a string (in characters).
+#'
+#' @param string input character vector
+#' @return numeric vector giving number of characters in each element of the
+#'   character vector.  Missing strings have missing length.
+#' @seealso \code{\link{nchar}} which this function wraps
+#' @export
+#' @examples
+#' str_length(letters)
+#' str_length(c("i", "like", "programming", NA))

--- a/tests/testthat/roxygen-example-1.R
+++ b/tests/testthat/roxygen-example-1.R
@@ -1,0 +1,29 @@
+##' Title
+##'
+##' Description
+##'
+##' Details
+##'
+##' @param x,y,z Descriptions for x, y, z
+##' @param a Description of a
+##' @param b
+##'   Description of b
+##' @section Important:
+##' Don't run with scissors!
+##' @export
+NULL
+
+##' Title
+##'
+##' Description
+##'
+##' Details
+##'
+##' @param x,y,z Descriptions for x, y, z
+##' @param a Description of a
+##' @param b
+##'   Description of b
+##' @section Important:
+##' Don't run with scissors!
+##' @export
+NULL

--- a/tests/testthat/test-cpp-parser.R
+++ b/tests/testthat/test-cpp-parser.R
@@ -1,0 +1,42 @@
+context("C++ Preparser")
+
+dropAttrs <- function(x) {
+  rapply(x, function(xx) {
+    attributes(xx) <- NULL
+    xx
+  }, how = "list")
+}
+
+test_that("The C++ parser works on example blocks / files", {
+
+  block <- readLines("roxygen-block-1.R")
+  parsed <- preparse_block(paste(block, collapse = "\n"))
+  block_1_expectation <- list(
+    introduction = "Title\n\nDescription\n\nDetails\n\n",
+    param = "x,y,z Descriptions for x, y, z",
+    param = "a Description of a",
+    param = "b\nDescription of b",
+    section = "Important:\nDon't run with scissors!",
+    export = ""
+  )
+
+  expect_identical(
+    dropAttrs(parsed),
+    block_1_expectation
+  )
+
+  expect_equal(
+    unlist(lapply(parsed, function(x) attr(x, "row")), use.names = FALSE),
+    c(1, 7, 8, 9, 11, 13)
+  )
+
+  parsed <- preparse_file("roxygen-example-1.R")
+  expect_identical(
+    dropAttrs(parsed),
+    list(
+      block_1_expectation,
+      block_1_expectation
+    )
+  )
+
+})


### PR DESCRIPTION
This PR introduces two functions:
1. `preparse_block:` takes an Roxygen block as a single string, and produces preparsed (key/value) output,
2. `preparse_file:` takes a file and preparses all encountered Roxygen blocks.
