### PR TITLE
Fix @describeIn with plain functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   was the cause of that.
 
 * Don't wrap `Authors@R` field in `DESCRIPTION` (@krlmlr, 284).
+* `@describeIn` with plain functions now correctly includes the function name. (@jimhester, #285).
 
 # roxygen2 4.0.2
 

--- a/R/object.R
+++ b/R/object.R
@@ -28,6 +28,7 @@ default_name.rcclass <-   function(x) x$value@className
 default_name.rcmethod <-  function(x) x$value@name
 default_name.s3generic <- function(x) browser()
 default_name.s3method <-  function(x) attr(x$value, "s3method")
+default_name.function <-   function(x) x$alias
 default_name.default <-   function(x) NULL
 
 #' @export

--- a/tests/testthat/test-describein.R
+++ b/tests/testthat/test-describein.R
@@ -51,6 +51,17 @@ test_that("@describeIn class captures s4 generic name", {
   expect_equal(get_tag(out, "minidesc")$values$label, "mean")
 })
 
+test_that("@describeIn class captures function name", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Title
+    f <- function(x) 1
+
+    #' @describeIn f A
+    f2 <- function(x) 1
+    ")[[1]]
+
+  expect_equal(get_tag(out, "minidesc")$values$label, "f2")
+})
 
 test_that("Multiple @describeIn generic combined into one", {
   out <- roc_proc_text(rd_roclet(), "


### PR DESCRIPTION
Previously these did not include the function name in the list.
Fixes #285

I added a test for this and added a note to the news about it.  Let me know if there is anything else you need!
