### PR TITLE
Allow describeIn to be used with data documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
   was the cause of that.
 
 * Don't wrap `Authors@R` field in `DESCRIPTION` (@krlmlr, 284).
-* `@describeIn` with plain functions now correctly includes the function name. (@jimhester, #285).
+* `@describeIn` with plain functions now correctly includes the function name
+  and can be applied to data documentation. (@jimhester, #285, #288).
 
 # roxygen2 4.0.2
 

--- a/R/minidesc.R
+++ b/R/minidesc.R
@@ -70,7 +70,7 @@ build_label <- function(src, dest) {
     # Label S3 methods in generic with their class
     type <- "generic"
     label <- attr(src$value, "s3method")[2]
-  } else if (dest_type == "function" && src_type == "function") {
+  } else if (dest_type %in% c("function", "data") && src_type == "function") {
     # Multiple functions in one Rd labelled with function names
     type <- "function"
     label <- default_name(src)

--- a/tests/testthat/test-describein.R
+++ b/tests/testthat/test-describein.R
@@ -51,18 +51,6 @@ test_that("@describeIn class captures s4 generic name", {
   expect_equal(get_tag(out, "minidesc")$values$label, "mean")
 })
 
-test_that("@describeIn class captures function name", {
-  out <- roc_proc_text(rd_roclet(), "
-    #' Title
-    f <- function(x) 1
-
-    #' @describeIn f A
-    f2 <- function(x) 1
-    ")[[1]]
-
-  expect_equal(get_tag(out, "minidesc")$values$label, "f2")
-})
-
 test_that("Multiple @describeIn generic combined into one", {
   out <- roc_proc_text(rd_roclet(), "
     #' Title
@@ -78,4 +66,29 @@ test_that("Multiple @describeIn generic combined into one", {
   expect_equal(get_tag(out, "minidesc")$values$type, "generic")
   expect_equal(get_tag(out, "minidesc")$values$label, c("a", "b"))
   expect_equal(get_tag(out, "minidesc")$values$desc, c("A", "B"))
+})
+
+test_that("@describeIn class captures function name", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Title
+    f <- function(x) 1
+
+    #' @describeIn f A
+    f2 <- function(x) 1
+    ")[[1]]
+
+  expect_equal(get_tag(out, "minidesc")$values$label, "f2")
+})
+
+test_that("@describeIn class captures function name with data", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #' @name f
+    NULL
+
+    #' @describeIn f A
+    f2 <- function(x) 1
+    ")[[1]]
+
+  expect_equal(get_tag(out, "minidesc")$values$label, "f2")
 })


### PR DESCRIPTION
fixes #288 

The diff on the tests looks weird because I swapped the order of `Multiple @describeIn generic combined into one` and `@describeIn class captures function name`.  The only actual new test is `@describeIn class captures function name with data`.
