### PR TITLE
Conditionally generate \verb{} instead of \code{}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Convert markdown code (``` `` ```) to either `\code{}` or `\verb{}` 
   depending on whether it not it parses as R code. This should make it 
-  easier to include arbitrary "code" snippets in documentation with out
+  easier to include arbitrary "code" snippets in documentation without
   causing Rd failures (#654).
 
 * As well as storing roxygen options in the `Roxygen` field of the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # roxygen2 (development version)
 
+* Convert markdown code (``` `` ```) to either `\code{}` or `\verb{}` 
+  depending on whether it not it parses as R code. This should make it 
+  easier to include arbitrary "code" snippets in documentation with out
+  causing Rd failures (#654).
+
 * As well as storing roxygen options in the `Roxygen` field of the 
   `DESCRIPTION` you can now also store them in `man/roxygen/meta.R` (#889).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   depending on whether it not it parses as R code. This should make it 
   easier to include arbitrary "code" snippets in documentation without
   causing Rd failures (#654).
+
 * Inherting for a function with no arguments no longer throws a confusing
   error message (#898)
 

--- a/man/markdown-internals.Rd
+++ b/man/markdown-internals.Rd
@@ -43,13 +43,13 @@ The list of protected Rd tags is in \code{escaped_for_md}.
 
 Some Rd macros are treated specially:
 \itemize{
-\item For \code{if}, markdown is only allowed in the second argument.
+\item For \verb{if}, markdown is only allowed in the second argument.
 \item For \code{ifelse} markdown is allowed in the second and third arguments.
 }
 
 See also \code{roclet-rd.R} for the list of tags that
 uses the markdown-enabled parser. Some tags, e.g.
-\code{@aliases}, \code{@backref}, etc. only use the
+\verb{@aliases}, \verb{@backref}, etc. only use the
 standard Roxygen parser.
 }
 \keyword{internal}

--- a/man/parse_package.Rd
+++ b/man/parse_package.Rd
@@ -30,7 +30,7 @@ the input code. The defaults will do this for you in a test environment:
 for real code you'll need to generate the environment yourself.
 
 You can also set to \code{NULL} if you only want to get the tokenized code
-blocks only. This suppresses evaluation of \code{@eval} tags, and will not
+blocks only. This suppresses evaluation of \verb{@eval} tags, and will not
 find the code object associated with each block.}
 
 \item{registry}{A roclet tag registry: this is a named list where the

--- a/man/roclet.Rd
+++ b/man/roclet.Rd
@@ -34,7 +34,7 @@ values give tag parsing function. See \link{roxy_tag} for built-in options.
 code has been evaluated. This should only be needed if your roclet affects
 how code will evaluated. Should return a roclet.
 \item \code{roclet_process()} called after blocks have been evaluated; i.e. the
-\code{@eval} tag has been processed, and the object associated with each block
+\verb{@eval} tag has been processed, and the object associated with each block
 has been determined.
 \item \code{roclet_output()} is given the output from \code{roclet_process()} and should
 produce files on disk.

--- a/man/update_collate.Rd
+++ b/man/update_collate.Rd
@@ -16,7 +16,7 @@ alphabet puts letters in the same order, so you can't rely on alphabetic
 ordering if you need one file loaded before another. (This usually doesn't
 matter but is important for S4, where you need to make sure that classes are
 loaded before subclasses and generics are defined before methods.).
-You can override the default alphabetical ordering with \code{@include before.R},
+You can override the default alphabetical ordering with \verb{@include before.R},
 which specify that \code{before.R} must be loaded before the current file.
 
 Generally, you will not need to run this function yourself; it should be
@@ -28,9 +28,9 @@ collation order.
 This is not a roclet because roclets need the values of objects in a package,
 and those values can not be generated unless you've sourced the files,
 and you can't source the files unless you know the correct order.
-If there are no \code{@include} tags, roxygen2 will leave collate as is.
+If there are no \verb{@include} tags, roxygen2 will leave collate as is.
 This makes it easier to use roxygen2 with an existing collate directive,
-but if you remove all your \code{@include} tags, you'll need to also
+but if you remove all your \verb{@include} tags, you'll need to also
 manually delete the collate field.
 }
 

--- a/man/vignette_roclet.Rd
+++ b/man/vignette_roclet.Rd
@@ -12,7 +12,7 @@ By default, it will rebuild all vignettes if the source file is newer than
 the output pdf or html. (This means it will automatically re-build the
 vignette if you change the vignette source, but \emph{not} when you
 change the R code). If you want finer control, add a Makefile to
-\code{vignettes/} and roxygen2 will use that instead.
+\verb{vignettes/} and roxygen2 will use that instead.
 }
 \details{
 To prevent RStudio from re-building the vignettes again when checking

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -24,7 +24,7 @@ test_that("proper link references are added", {
 test_that("can not have [ inside of link", {
   expect_equal(
     markdown("`[[`. [subset()]"),
-    "\\code{[[}. \\code{\\link[=subset]{subset()}}"
+    "\\verb{[[}. \\code{\\link[=subset]{subset()}}"
   )
 })
 
@@ -298,9 +298,9 @@ test_that("[] is not picked up in code", {
   out2 <- roc_proc_text(rd_roclet(), "
     #' Title
     #'
-    #' @param connect_args \\code{[named list]}\\cr Connection arguments
-    #' Description, see \\code{[foobar]}.
-    #' Also \\code{[this_too]}.
+    #' @param connect_args \\verb{[named list]}\\cr Connection arguments
+    #' Description, see \\verb{[foobar]}.
+    #' Also \\verb{[this_too]}.
     foo <- function() {}")[[1]]
   expect_equivalent_rd(out1, out2)
 })

--- a/tests/testthat/test-markdown-state.R
+++ b/tests/testthat/test-markdown-state.R
@@ -30,7 +30,7 @@ test_that("turning on/off markdown globally", {
     foo <- function() {}")[[1]]
   expect_equal(
     get_tag(out1, "description")$values,
-    "Description with some \\code{code} included. \\code{More code.}"
+    "Description with some \\code{code} included. \\verb{More code.}"
   )
 })
 
@@ -56,7 +56,7 @@ test_that("turning on/off markdown locally", {
     foo <- function() {}")[[1]]
   expect_equal(
     get_tag(out1, "description")$values,
-    "Description with some \\code{code} included. \\code{More code.}"
+    "Description with some \\code{code} included. \\verb{More code.}"
   )
 
   ## on / off
@@ -80,7 +80,7 @@ test_that("turning on/off markdown locally", {
     foo <- function() {}")[[1]]
   expect_equal(
     get_tag(out1, "description")$values,
-    "Description with some \\code{code} included. \\code{More code.}"
+    "Description with some \\code{code} included. \\verb{More code.}"
   )
 
 })

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -1,4 +1,4 @@
-test_that("backticks are converted to \\code", {
+test_that("backticks are converted to \\code & \\verb", {
   out1 <- roc_proc_text(rd_roclet(), "
     #' Title
     #'
@@ -8,7 +8,7 @@ test_that("backticks are converted to \\code", {
   out2 <- roc_proc_text(rd_roclet(), "
     #' Title
     #'
-    #' Description with some \\code{code} included. \\code{More code.}
+    #' Description with some \\code{code} included. \\verb{More code.}
     foo <- function() {}")[[1]]
   expect_equivalent_rd(out1, out2)
 })
@@ -50,7 +50,7 @@ test_that("inline code escapes %", {
     f <- function() 1
   ")[[1]]
 
-  expect_equal(out$get_field("title")$values, "\\code{0.5\\%}")
+  expect_equal(out$get_field("title")$values, "\\verb{0.5\\%}")
 })
 
 test_that("code blocks escape %", {
@@ -73,7 +73,7 @@ test_that("inline code works with < and >", {
     f <- function() 1
   ")[[1]]
 
-  expect_equal(out$get_field("title")$values, "\\code{SELECT <name> FROM <table>}")
+  expect_equal(out$get_field("title")$values, "\\verb{SELECT <name> FROM <table>}")
 })
 
 test_that("itemized lists work", {
@@ -394,8 +394,8 @@ test_that("Do not pick up `` in arguments \\item #519", {
     #'
     #' Description.
     #'
-    #' @param `_arg1` should not be code. But \\code{this should}.
-    #' @param `_arg2` should not be code, either. \\code{But this.}
+    #' @param `_arg1` should not be code. But \\verb{this should}.
+    #' @param `_arg2` should not be code, either. \\verb{But this.}
     #'
     foo <- function(`_arg1`, `_arg2`) {}")[[1]]
   expect_equivalent_rd(out1, out2)

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -1,3 +1,5 @@
+# code --------------------------------------------------------------------
+
 test_that("backticks are converted to \\code & \\verb", {
   out1 <- roc_proc_text(rd_roclet(), "
     #' Title
@@ -44,26 +46,21 @@ test_that("code blocks work", {
 })
 
 test_that("inline code escapes %", {
-  out <- roc_proc_text(rd_roclet(), "
-    #' `0.5%`
-    #' @md
-    f <- function() 1
-  ")[[1]]
+  expect_equal(markdown("`5%`"), "\\verb{5\\%}")
+  expect_equal(markdown("`'5%'`"), "\\code{'5\\%'}")
+})
 
-  expect_equal(out$get_field("title")$values, "\\verb{0.5\\%}")
+test_that("inline verbatim escapes Rd special chars", {
+  expect_equal(markdown("`{`"), "\\verb{\\{}")
+  expect_equal(markdown("`}`"), "\\verb{\\}}")
+  expect_equal(markdown("`\\`"), "\\verb{\\\\}")
 })
 
 test_that("code blocks escape %", {
-  out <- roc_proc_text(rd_roclet(), "
-    #' ```
-    #' 1:10 %>% mean()
-    #' ```
-    #'
-    #' @md
-    f <- function() 1
-  ")[[1]]
-
-  expect_equal(out$get_field("title")$values, "\\preformatted{1:10 \\%>\\% mean()\n}")
+  expect_equal(
+    markdown("```\n1:10 %>% mean()\n```"),
+    "\\preformatted{1:10 \\%>\\% mean()\n}"
+  )
 })
 
 test_that("inline code works with < and >", {
@@ -75,6 +72,9 @@ test_that("inline code works with < and >", {
 
   expect_equal(out$get_field("title")$values, "\\verb{SELECT <name> FROM <table>}")
 })
+
+
+# lists -------------------------------------------------------------------
 
 test_that("itemized lists work", {
   out1 <- roc_proc_text(rd_roclet(), "
@@ -187,6 +187,9 @@ test_that("nested lists are OK", {
     foo <- function() {}")[[1]]
   expect_equivalent_rd(out1, out2)
 })
+
+
+# inline formatting -------------------------------------------------------
 
 test_that("emphasis works", {
   out1 <- roc_proc_text(rd_roclet(), "


### PR DESCRIPTION
`\code{}` is supposed to be used with [R code](https://cran.rstudio.com/doc/manuals/r-devel/R-exts.html#Marking-text):

> `\code{text}`
> Indicate text that is a literal example of a piece of an R program, e.g., a fragment of R code or the name of an R object. Text is entered in R-like syntax, and displayed using typewriter font where possible. Macros \var and \link are interpreted within text.

Previously we were using it to translate every use of backticks, which causes problems if you're attempting to use  `` `/` ``, `` `{` `` and `` `}` ``. This patch uses `\code{}` the contents of backticks parses, and otherwise falls backs to `\verb{}` (with more escaping). 