### PR TITLE
Escape Rd comments in markdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # roxygen2 (development version)
 
+* Rd comments (`%`) are automatically escaped in markdown text. Existing
+  code that uses `\%` is automatically repaired; if you're generating
+  more exotic sequences like `\\%` you'll need to put them inside 
+  backticks (#879)
+
 * As well as storing roxygen options in the `Roxygen` field of the 
   `DESCRIPTION` you can now also store them in `man/roxygen/meta.R` (#889).
 

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -137,7 +137,7 @@ parse_link <- function(destination, contents) {
     )
 
   } else {
-    contents <- gsub("%", "\\\\%", mdxml_link_text(contents))
+    contents <- mdxml_link_text(contents)
 
     list(
       paste0(

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -344,6 +344,13 @@ So far so good. \\preformatted{ *these are not
   expect_equal(get_tag(out1, "description")[[2]], desc1)
 })
 
+test_that("% is automatically escaped", {
+  expect_equal(markdown("5%"), "5\\%")
+
+  # Even if it was escaped before
+  expect_equal(markdown("5\\%"), "5\\%")
+})
+
 test_that("% and $ and _ are not unescaped", {
   out1 <- roc_proc_text(rd_roclet(), "
     #' Title


### PR DESCRIPTION
I think this is a worthwhile change — in order to be backward compatible `\%` will still generate `\%` so if you want to generate `\\%` you'll need to put it in a code block (or jump through considerable gymnastics). But I think this happens rarely in practice, while it's easy to forget that you need to escape `%`. If you do write `5%`, error messages are likely to be confusing because they'll usually come from invalid `.Rd` syntax (e.g. because a closing `}` is eaten by the comment).

Fixes #879