### PR TITLE
Make sure md parser does not return empty vector

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -30,6 +30,7 @@ mdxml_children_to_rd_top <- function(xml, state) {
   out <- c(out, mdxml_close_sections(state))
   rd <- paste0(out, collapse = "")
   secs <- strsplit(rd, state$section_tag, fixed = TRUE)[[1]]
+  if (length(secs) == 0) secs <- ""
   str_trim(secs)
 }
 

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -549,3 +549,9 @@ test_that("headings and empty sections", {
   out1 <- roc_proc_text(rd_roclet(), text1)[[1]]
   expect_false("details" %in% names(out1$fields))
 })
+
+test_that("markdown() on empty input", {
+  expect_identical(markdown(""), "")
+  expect_identical(markdown("  "), "")
+  expect_identical(markdown("\n"), "")
+})

--- a/tests/testthat/test-rd-includermd.R
+++ b/tests/testthat/test-rd-includermd.R
@@ -136,3 +136,18 @@ test_that("links to functions, with anchors", {
   )
   expect_equal_strings(out1$fields$details$values, exp_details)
 })
+
+test_that("empty Rmd", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  tag <- roxy_tag("includeRmd", tmp)
+
+  cat("", sep = "", file = tmp)
+  expect_equal(rmd_eval_rd(tmp, tag), "")
+
+  cat("  ", sep = "", file = tmp)
+  expect_equal(rmd_eval_rd(tmp, tag), "")
+
+  cat("\n", sep = "", file = tmp)
+  expect_equal(rmd_eval_rd(tmp, tag), "")
+})


### PR DESCRIPTION
Because this could cause problems downstream.

This PR also fixes #909, just like #910 does, but it makes sense to have both of them.