### PR TITLE
Markdown improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,10 @@
 * Rd comments (`%`) are automatically escaped. You will need to replace any
   existing uses of `\%` with `%` (#879).
 
+* Markdown links can now contain formatting. E.g. in
+  `See [*Formatting*][formatting]` the link text will be emphasised.
+  Similarly in external links: `See [*this web page*](https://...)` (#919).
+
 * Use of unsupported markdown features (blockquotes, headings, inline HTML, 
   and horizontal rules) now gnerate more informative error messages (#804).
 

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -82,7 +82,7 @@ add_linkrefs_to_md <- function(text) {
 #' @noRd
 #' @importFrom xml2 xml_name
 
-parse_link <- function(destination, contents) {
+parse_link <- function(destination, contents, state) {
 
   ## Not a [] or [][] type link, remove prefix if it is
   if (! grepl("^R:", destination)) return(NULL)
@@ -139,7 +139,7 @@ parse_link <- function(destination, contents) {
     )
 
   } else {
-    contents <- mdxml_link_text(contents)
+    contents <- mdxml_link_text(contents, state)
 
     list(
       paste0(

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -33,7 +33,8 @@ mdxml_children_to_rd <- function(xml, state) {
 
 #' @importFrom xml2 xml_name xml_type xml_text xml_contents xml_attr xml_children
 mdxml_node_to_rd <- function(xml, state) {
-  if (!inherits(xml, "xml_node") || xml_type(xml) != "element") {
+  if (!inherits(xml, "xml_node") ||
+      ! xml_type(xml) %in% c("text", "element")) {
     roxy_tag_warning(state$tag, "Internal markdown translation failure")
     return("")
   }
@@ -188,12 +189,13 @@ mdxml_heading <- function(xml, state) {
   if (! state$has_sections && level == 1) {
     return(mdxml_unsupported(xml, state$tag, "level 1 markdown headings"))
   }
+  txt <- map_chr(xml_contents(xml), mdxml_node_to_rd, state)
   head <- paste0(
     mdxml_close_sections(state, level),
     "\n",
     if (level == 1) paste0(state$section_tag, "\\section{"),
     if (level > 1) "\\subsection{",
-    xml_text(xml),
+    paste(txt, collapse = ""),
     "}{")
   state$section <- c(state$section, level)
   head

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -58,14 +58,15 @@ mdxml_node_to_rd <- function(xml, state) {
     item = mdxml_item(xml, state),
     link = mdxml_link(xml),
     image = mdxml_image(xml),
+    heading = mdxml_heading(xml, state),
 
     # Only supported when including Rmds
-    heading = mdxml_heading(xml, state),
+    html_block = mdxml_html_block(xml, state),
+    html_inline = mdxml_html_inline(xml, state),
 
     # Not supported
     block_quote = mdxml_unsupported(xml, state$tag, "block quotes"),
     hrule = mdxml_unsupported(xml, state$tag, "horizontal rules"),
-    html_inline = mdxml_unsupported(xml, state$tag, "inline HTML"),
     mdxml_unknown(xml, state$tag)
   )
 }
@@ -196,6 +197,28 @@ mdxml_heading <- function(xml, state) {
     "}{")
   state$section <- c(state$section, level)
   head
+}
+
+mdxml_html_block <- function(xml, state) {
+  if (state$tag$tag != "includeRmd") {
+    return(mdxml_unsupported(xml, state$tag, "HTML blocks"))
+  }
+  paste0(
+    "\\if{html}{\\out{\n",
+    gsub("}", "\\}", xml_text(xml), fixed = TRUE),
+    "}}\n"
+  )
+}
+
+mdxml_html_inline <- function(xml, state) {
+  if (state$tag$tag != "includeRmd") {
+    return(mdxml_unsupported(xml, state$tag, "inline HTML"))
+  }
+  paste0(
+    "\\if{html}{\\out{",
+    gsub("}", "\\}", xml_text(xml), fixed = TRUE),
+    "}}"
+  )
 }
 
 #' @importFrom utils head tail

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -52,7 +52,7 @@ mdxml_node_to_rd <- function(xml, state) {
     linebreak = mdxml_break(state),
 
     code = mdxml_code(xml, state),
-    code_block = paste0("\\preformatted{", escape_verb(xml_text(xml)), "}"),
+    code_block = mdxml_code_block(xml, state),
 
     table = mdxml_table(xml, state),
     list = mdxml_list(xml, state),
@@ -95,6 +95,18 @@ mdxml_code <- function(xml, tag) {
   } else {
     paste0("\\verb{", escape_verb(code), "}")
   }
+}
+
+mdxml_code_block <- function(xml, state) {
+  info <- xml_attr(xml, "info")[1]
+  if (is.na(info) || nchar(info[1]) == 0) info <- NA_character_
+  paste0(
+    if (!is.na(info)) paste0("\\if{html}{\\out{<div class=\"", info, "\">}}"),
+    "\\preformatted{",
+    escape_verb(xml_text(xml)),
+    "}",
+    if (!is.na(info)) "\\if{html}{\\out{</div>}}"
+  )
 }
 
 can_parse <- function(x) {

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -414,3 +414,19 @@ test_that("linebreak in 'text' of [text][foo] turns into single space", {
 
 })
 
+test_that("markup in link text", {
+  out1 <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #'
+    #' Description, see [`code link text`][func].
+    #' And also [`code as well`](https://external.com).
+    #' @md
+    foo <- function() {}")[[1]]
+  out2 <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #'
+    #' Description, see \\code{\\link[=func]{code link text}}.
+    #' And also \\href{https://external.com}{\\verb{code as well}}.
+    foo <- function() {}")[[1]]
+  expect_equivalent_rd(out1, out2)
+})

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -22,7 +22,7 @@ test_that("code blocks work", {
     #' Description
     #'
     #' Details with a code block:
-    #' ```r
+    #' ```
     #' x <- 1:10 %>%
     #'   multiply_by(10) %>%
     #'   add(42)
@@ -39,6 +39,36 @@ test_that("code blocks work", {
     #'   multiply_by(10) \\%>\\%
     #'   add(42)
     #' }
+    #'
+    #' Normal text again.
+    foo <- function() {}")[[1]]
+  expect_equivalent_rd(out1, out2)
+})
+
+test_that("code block with language creates HTML tag", {
+  out1 <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #'
+    #' Description
+    #'
+    #' Details with a code block:
+    #' ```r
+    #' x <- 1:10 %>%
+    #'   multiply_by(10) %>%
+    #'   add(42)
+    #' ```
+    #' Normal text again.
+    #' @md
+    foo <- function() {}")[[1]]
+  out2 <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #'
+    #' Description
+    #'
+    #' Details with a code block:\\if{html}{\\out{<div class=\"r\">}}\\preformatted{x <- 1:10 \\%>\\%
+    #'   multiply_by(10) \\%>\\%
+    #'   add(42)
+    #' }\\if{html}{\\out{</div>}}
     #'
     #' Normal text again.
     foo <- function() {}")[[1]]

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -569,3 +569,34 @@ test_that("markdown() on empty input", {
   expect_identical(markdown("  "), "")
   expect_identical(markdown("\n"), "")
 })
+
+test_that("markup in headings", {
+  text1 <- "
+    #' Title
+    #'
+    #' Description.
+    #'
+    #' @details
+    #' Leading text goes into details.
+    #' # Section with `code`
+    #' ## Subsection with **strong**
+    #' Yes.
+    #' @md
+    #' @name x
+    NULL
+  "
+  out1 <- roc_proc_text(rd_roclet(), text1)[[1]]
+  expect_equal(
+    out1$get_value("rawRd"),
+    paste(
+      sep = "\n",
+      "\\section{Section with \\code{code}}{",
+      "\\subsection{Subsection with \\strong{strong}}{",
+      "",
+      "Yes.",
+      "}",
+      "",
+      "}"
+      )
+  )
+})

--- a/tests/testthat/test-rd-includermd.R
+++ b/tests/testthat/test-rd-includermd.R
@@ -187,7 +187,7 @@ test_that("html block", {
   cat(sep = "\n", file = tmp,
     "Text at the front",
     "",
-    "<div>HTML block</div>",
+    "<a id=\"test\"></a>",
     "",
     "Text")
   rox <- sprintf("
@@ -198,9 +198,7 @@ test_that("html block", {
   out1 <- roc_proc_text(rd_roclet(), rox)[[1]]
   exp_details <- paste0(
     "Text at the front",
-    "\\if{html}{\\out{\n<div>\n}}",
-    "HTML block",
-    "\\if{html}{\\out{\n</div>\n}}",
+    "\\if{html}{\\out{<a id=\"test\">}}\\if{html}{\\out{</a>}}",
     "Text"
   )
   expect_equal_strings(out1$get_value("details"), exp_details)

--- a/tests/testthat/test-rd-includermd.R
+++ b/tests/testthat/test-rd-includermd.R
@@ -151,3 +151,57 @@ test_that("empty Rmd", {
   cat("\n", sep = "", file = tmp)
   expect_equal(rmd_eval_rd(tmp, tag), "")
 })
+
+test_that("inline html", {
+  skip_if_not(rmarkdown::pandoc_available())
+
+  tmp <- tempfile(fileext = ".md")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  cat(sep = "\n", file = tmp,
+    "Text at the front",
+    "",
+    "",
+    "## Subsection in details",
+    "",
+    "Some subsection text with <span>inline html</span>.")
+  rox <- sprintf("
+    #' Title
+    #' @includeRmd %s
+    #' @name foobar
+    NULL", tmp)
+  out1 <- roc_proc_text(rd_roclet(), rox)[[1]]
+  exp_details <- paste0(
+    "Text at the front",
+    "\\subsection{Subsection in details}{",
+    "Some subsection text with ",
+    "\\if{html}{\\out{<span>}}inline html\\if{html}{\\out{</span>}}.\n}"
+  )
+  expect_equal_strings(out1$get_value("details"), exp_details)
+})
+
+test_that("html block", {
+  skip_if_not(rmarkdown::pandoc_available())
+
+  tmp <- tempfile(fileext = ".md")
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  cat(sep = "\n", file = tmp,
+    "Text at the front",
+    "",
+    "<div>HTML block</div>",
+    "",
+    "Text")
+  rox <- sprintf("
+    #' Title
+    #' @includeRmd %s
+    #' @name foobar
+    NULL", tmp)
+  out1 <- roc_proc_text(rd_roclet(), rox)[[1]]
+  exp_details <- paste0(
+    "Text at the front",
+    "\\if{html}{\\out{\n<div>\n}}",
+    "HTML block",
+    "\\if{html}{\\out{\n</div>\n}}",
+    "Text"
+  )
+  expect_equal_strings(out1$get_value("details"), exp_details)
+})


### PR DESCRIPTION
* Allow HTML blocks and inline HTML in Rmd files included via `@includeRmd`. They are converted to `\if{html}{\out{...}}`.
* Allow markup in markdown headings. E.g. 
    ```
    # This is a **strong** heading
    ```
* Allow markup in markdown links. E.g.
    ```
    This is a [`link to an R object`][object].
    This is an [`external link`](https://external.link)
    ```
* Keep language info from fences.
    ````
    ```r
    ...
    ```
    ````
  will generate
    ```
    <div class="r"><pre>...</pre></div>
    ```
  in HTML.


Maybe we could mention some of these in the NEWS?