### PR TITLE
Add HTML class and data to inter-package anchored links

### DIFF
--- a/R/rd-r6.R
+++ b/R/rd-r6.R
@@ -260,7 +260,15 @@ r6_inherited_method_list <- function(block, r6data) {
     paste0("\\out{", details, "}"),
     "\\itemize{",
     sprintf(
-      "\\item \\href{../../%s/html/%s.html#method-%s}{\\code{%s::%s$%s()}}",
+      paste0(
+        "\\item \\out{<span class=\"pkg-link\" data-pkg=\"%s\" ",
+        "data-topic=\"%s\" data-id=\"%s\">}",
+        "\\href{../../%s/html/%s.html#method-%s}{\\code{%s::%s$%s()}}",
+        "\\out{</span>}"
+      ),
+      super_meth$package,
+      super_meth$classname,
+      super_meth$name,
       super_meth$package,
       super_meth$classname,
       super_meth$name,

--- a/tests/testthat/roxygen-block-3-B.Rd
+++ b/tests/testthat/roxygen-block-3-B.Rd
@@ -43,8 +43,8 @@ Class B details.
 \if{html}{
 \out{<details open ><summary>Inherited methods</summary>}
 \itemize{
-\item \href{../../roxygen2/html/A.html#method-meth2}{\code{roxygen2::A$meth2()}}
-\item \href{../../roxygen2/html/A.html#method-meth3}{\code{roxygen2::A$meth3()}}
+\item \out{<span class="pkg-link" data-pkg="roxygen2" data-topic="A" data-id="meth2">}\href{../../roxygen2/html/A.html#method-meth2}{\code{roxygen2::A$meth2()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="roxygen2" data-topic="A" data-id="meth3">}\href{../../roxygen2/html/A.html#method-meth3}{\code{roxygen2::A$meth3()}}\out{</span>}
 }
 \out{</details>}
 }

--- a/tests/testthat/roxygen-block-3-C.Rd
+++ b/tests/testthat/roxygen-block-3-C.Rd
@@ -54,9 +54,9 @@ Classs C details.
 \if{html}{
 \out{<details open ><summary>Inherited methods</summary>}
 \itemize{
-\item \href{../../roxygen2/html/A.html#method-meth3}{\code{roxygen2::A$meth3()}}
-\item \href{../../roxygen2/html/B.html#method-meth1}{\code{roxygen2::B$meth1()}}
-\item \href{../../roxygen2/html/B.html#method-meth4}{\code{roxygen2::B$meth4()}}
+\item \out{<span class="pkg-link" data-pkg="roxygen2" data-topic="A" data-id="meth3">}\href{../../roxygen2/html/A.html#method-meth3}{\code{roxygen2::A$meth3()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="roxygen2" data-topic="B" data-id="meth1">}\href{../../roxygen2/html/B.html#method-meth1}{\code{roxygen2::B$meth1()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="roxygen2" data-topic="B" data-id="meth4">}\href{../../roxygen2/html/B.html#method-meth4}{\code{roxygen2::B$meth4()}}\out{</span>}
 }
 \out{</details>}
 }


### PR DESCRIPTION
These currently happen when linking to inherited R6
methods.

Closes (the roxygen part of) #933.