### PR TITLE
Fix hashing files with Unicode paths, on Windows

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -91,12 +91,26 @@ same_contents <- function(path, contents) {
 
   contents <- paste0(paste0(contents, collapse = "\n"), "\n")
 
-  text_hash <- digest::digest(contents, serialize = FALSE)
+  text_hash <- md5_string(contents)
 
-  path <- normalizePath(path, mustWork = TRUE)
-  file_hash <- digest::digest(file = path)
+  file_hash <- md5_file(path)
 
   identical(text_hash, file_hash)
+}
+
+md5_string <- function(text) {
+  digest::digest(text, serialize = FALSE, algo = "md5")
+}
+
+md5_file <- function(path) {
+  # tools::md5sum returns NA if it cannot open the file. This also happens
+  # for Unicode file names on Windows, so we try a bit harder.
+  md5 <- tools::md5sum(path)[[1]]
+  if (is.na(md5)) {
+    data <- readBin(path, raw(), n = file.info(path)$size)
+    md5 <- digest::digest(data, serialize = FALSE, algo = "md5")
+  }
+  md5
 }
 
 compact <- function(x) {

--- a/tests/testthat/test-rd.R
+++ b/tests/testthat/test-rd.R
@@ -78,6 +78,27 @@ test_that("can generate nonASCII document", {
   expect_output(roxygenise(test_pkg, roclets = "rd"), NA)
 })
 
+test_that("non ascii paths are fine", {
+  skip("Fails currently")
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  path <- file.path(tmp, "trickyx")
+  path2 <- file.path(tmp, "tricky-\u0151")
+  dir.create(path, recursive = TRUE)
+  file.copy(
+    normalizePath("testNonASCII"),
+    normalizePath(path),
+    recursive = TRUE
+  )
+  file.rename(path, path2)
+  test_pkg <- normalizePath(file.path(path2, "testNonASCII"))
+
+  expect_error(roxygenise(test_pkg, roclets = "rd"), NA)
+
+  rd_path <- file.path(test_pkg, "man", "printChineseMsg.Rd")
+  expect_true(file.exists(rd_path))
+})
+
 test_that("unicode escapes are ok", {
   test_pkg <- temp_copy_pkg(test_path('testUtf8Escape'))
   on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,4 +10,16 @@ test_that("nice_name protects against invalid characters", {
   expect_equal(nice_name("[.a"), "sub-.a")
 })
 
-
+test_that("same_contents with Unicode file names on Windows", {
+  skip_on_cran()
+  if (.Platform$OS.type != "windows") skip("Only on windows")
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  dir.create(tmp)
+  path <- file.path(tmp, "tricky-\u0151")
+  contents <- "foobar"
+  # Need to write raw, otherwise it will be \r\n on Windows
+  writeBin(charToRaw(paste0(contents, "\n")), con = path)
+  expect_silent(res <- same_contents(path, contents))
+  expect_true(res)
+})


### PR DESCRIPTION
This fixes hashing files with Unicode paths, and thus `same_contents()` as well. Both `digest::digest()` and `tools::md5sum()` are broken in this case, the latter returns `NA`. We need to read in the contents and then hash that if this happens.

Note that this does not completely fix roxygen2 on Unicode paths, because base R has a lot of problems working with them in general. I have added a test case for this, it currently fails, so it is skipped.