### PR TITLE
Do not escape within \dontshow etc in \examples

### DIFF
--- a/R/rd-examples.R
+++ b/R/rd-examples.R
@@ -37,13 +37,26 @@ format.rd_section_examples <- function(x, ...) {
   rd_macro(x$type, value, space = TRUE)
 }
 
-# Works like escape, but unescapes special rd example commands.
+# We take out the \dontshow{} etc. commands, because these should be
+# left as is, to allow the user to escape braces for example:
+# #' @examples
+# #' \\dontshow{ \{ }
+# #' # Hidden!
+# #' \\dontshow{ \} }
+#
+# Otherwise, it works like escape, but unescapes special rd example commands.
 # Also unescapes quotes because they must already be in strings and hence
 # don't need an additional layer of quoting.
 escape_examples <- function(x) {
+  ex_tags <- c("\\dontshow", "\\dontrun", "\\donttest", "\\testonly")
+  rd_tags <- find_fragile_rd_tags(x, ex_tags)
+  x <- x0 <- protect_rd_tags(x, rd_tags)
+
+  attr(x, "roxygen-markdown-subst") <- NULL
   x <- escape(x)
   x <- gsub("\\\\dont", "\\dont", x, fixed = TRUE)
   x <- gsub("\\\\'", "\\'", x, fixed = TRUE)
   x <- gsub('\\\\"', '\\"', x, fixed = TRUE)
-  x
+
+  rd(unescape_rd_for_md(x, x0))
 }

--- a/tests/testthat/test-rd-examples-dotrun-escape.txt
+++ b/tests/testthat/test-rd-examples-dotrun-escape.txt
@@ -1,7 +1,7 @@
 > out$get_section("examples")
 \examples{
-\dontshow{ \\{ }
+\dontshow{ \{ }
 # Hidden!
-\dontshow{ \\} }
+\dontshow{ \} }
 } 
 

--- a/tests/testthat/test-rd-examples-dotrun-escape.txt
+++ b/tests/testthat/test-rd-examples-dotrun-escape.txt
@@ -1,0 +1,7 @@
+> out$get_section("examples")
+\examples{
+\dontshow{ \\{ }
+# Hidden!
+\dontshow{ \\} }
+} 
+

--- a/tests/testthat/test-rd-examples.R
+++ b/tests/testthat/test-rd-examples.R
@@ -98,6 +98,26 @@ test_that("escapes within strings are not double escaped", {
   expect_equal(escape_examples("'34.00\\'"), rd("'34.00\\'"))
 })
 
-test_that("\\dontrun is not escaped", {
+test_that("\\dontrun etc. is not escaped #1", {
   expect_equal(escape_examples("\\dontrun{x <- 1}"), rd("\\dontrun{x <- 1}"))
+
+  expect_equal(
+    escape_examples("\\dontrun{ \\{ x <- 1 \\} }"),
+    rd("\\dontrun{ \\{ x <- 1 \\} }")
+  )
+})
+
+test_that("\\dontrun etc. is not escaped #2", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' @name a
+    #' @title a
+    #' @examples
+    #' \\dontshow{ \\{ }
+    #' # Hidden!
+    #' \\dontshow{ \\} }
+    NULL")[[1]]
+
+  verify_output(test_path("test-rd-examples-dotrun-escape.txt"), {
+    out$get_section("examples")
+  })
 })


### PR DESCRIPTION
Closes #954.