### PR TITLE
Small typo in brackets

### DIFF
--- a/vignettes/rd.Rmd
+++ b/vignettes/rd.Rmd
@@ -639,7 +639,7 @@ Three other tags make it easier for the user to find documentation within R's he
 
 *   Use `@keywords keyword1 keyword2 ...` to add standardised keywords. 
     Keywords are optional, but if present, must be taken from the 
-    predefined list found `file.path(R.home("doc"), "KEYWORDS"))`.
+    predefined list found `file.path(R.home("doc"), "KEYWORDS")`.
 
 Apart from `@keywords internal`, these tags are not very useful because most people find documentation using Google. `@keywords internal` is useful because it removes the function from the documentation index; it's useful for functions aimed primarily at other developers, not typical users of the package.
 


### PR DESCRIPTION
One bracket should be removed.

One other thing though:
> Apart from `@keywords internal`, these tags are not very useful because most people find documentation using Google. 

I disagree here, especially after feedback from our users. Use case: we have a function that determines if bacteria are multi-resistant, called `mdro()`. The outcome could be MDR (multi-drug-resistant) or XDR (extensively drug-resistant). If a users puts in `?XDR` we would like them to get to the `mdro()` page that tells about it, so we added `@aliases MDR XDR`. Seems *very* useful to me and is very much faster than searching Google. So I think you're underestimating aliases here :)