### PR TITLE
Fix partial match of contents

### DIFF
--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -312,7 +312,7 @@ find_sections <- function(topic) {
     titles <- map_chr(map(tag, 1), rd2text)
     contents <- map_chr(map(tag, 2), rd2text)
 
-    list(title = titles, contents = contents)
+    list(title = titles, content = contents)
   } else {
     topic$get_value("section")
   }


### PR DESCRIPTION
I believe this list value should be named `content`, rather than
`contents` to match the existing code.

I found this due to a partial match warning when using roxygen 7.0.0, but looking at the previous versions of the code I think this should be `content` rather than `contents`, as that was what the function signature for [roxy_field_section()](https://github.com/jimhester/roxygen/blob/59675d8db9c73e7c5535de7eb63a7d2861baf857/R/rd-section.R#L19) was, and also what the usage of this list shows.