### PR TITLE
Convert embedded newlines as well

### DIFF
--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -12,6 +12,9 @@ write_lines <- function(text, path) {
     line_ending <- "\n"
   }
 
+  # we need to convert any embedded newlines as well
+  text <- gsub("\r?\n", line_ending, text)
+
   path <- file(path, open = "wb")
   base::writeLines(enc2utf8(text), path, sep = line_ending, useBytes = TRUE)
   close(path)


### PR DESCRIPTION
In some cases write_lines takes a vector of lines to write, in others the lines are already collapsed, so we have to rewrite the embedded newlines as well.

Fixes https://github.com/r-lib/roxygen2/issues/989