### PR TITLE
Improve error message for R6 in extract_r6_methods()

### DIFF
--- a/R/object-r6.R
+++ b/R/object-r6.R
@@ -44,7 +44,16 @@ extract_r6_methods <- function(x) {
     x$public_methods[method_nms],
     function(m) {
       ref <- utils::getSrcref(m)
-      if (is.null(ref)) stop("R6 class without source references. Try re-installing with installation option '--with-keep.source'.")
+      if (is.null(ref)) {
+        name <- x$classname %||% NA
+        stop(
+          "R6 class ", if (!is.na(name)) paste0("(", name, ") "),
+          "without source references. ",
+          "If you use the `installed` load method in `DESCRIPTION`, then ",
+          "try re-installing the package with option '--with-keep.source'. ",
+          "E.g. `install.packages(..., INSTALL_OPTS = \"--with-keep.source\")`."
+        )
+      }
       utils::getSrcLocation(ref)
     }
   )

--- a/R/object-r6.R
+++ b/R/object-r6.R
@@ -44,7 +44,7 @@ extract_r6_methods <- function(x) {
     x$public_methods[method_nms],
     function(m) {
       ref <- utils::getSrcref(m)
-      if (is.null(ref)) stop("R6 class without source references")
+      if (is.null(ref)) stop("R6 class without source references. Try re-installing with installation option '--with-keep.source'.")
       utils::getSrcLocation(ref)
     }
   )


### PR DESCRIPTION
Thanks for adding support for `R6`!  I've been looking forward to it for a while and I'm excited that it's here.

In this PR, I propose adding a bit more information to an error message I encountered the first time that I tried `roxygen2`  7.0.x with a package that has `R6` objects. It took me a while to go from the error message *"R6 class without source references."*, work back through the `roxygen2`  source code, and figure out that I needed to install my package with `--with-keep.source`. I think my proposed change would help others deal with this error a bit more easily.