### PR TITLE
Refactor writing Win/Unix line endings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 (development version)
 
+* roxygen2 now keeps using Windows (CR LF) line endings for files that
+  already have CR LF line endings, and uses LF for new files (#989).
+
 # roxygen2 7.0.2
 
 * `\example{}` escaping has been improved (again!) so that special escapes 

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -5,15 +5,7 @@ read_lines <- function(path, n = -1L) {
   base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
 }
 
-write_lines <- function(text, path, line_ending = NULL) {
-  if (is.null(line_ending)) {
-    if (has_windows_le(path)) {
-      line_ending <- "\r\n"
-    } else {
-      line_ending <- "\n"
-    }
-  }
-
+write_lines <- function(text, path, line_ending = detect_line_ending(path)) {
   # we need to convert any embedded newlines as well
   text <- gsub("\r?\n", line_ending, text)
 
@@ -22,9 +14,9 @@ write_lines <- function(text, path, line_ending = NULL) {
   close(path)
 }
 
-has_windows_le <- function(path) {
-  tryCatch(
-    expr = isTRUE(grepl("\r\n", suppressWarnings(readChar(path, nchars = 500)))),
-    error = function(e) FALSE
-  )
+detect_line_ending <- function(path) {
+  tryCatch({
+    samp <- suppressWarnings(readChar(path, nchars = 500))
+    if (isTRUE(grepl("\r\n", samp))) "\r\n" else "\n"
+  }, error = function(e) "\n")
 }

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -5,11 +5,13 @@ read_lines <- function(path, n = -1L) {
   base::readLines(path, n = n, encoding = "UTF-8", warn = FALSE)
 }
 
-write_lines <- function(text, path) {
-  if (has_windows_le(path)) {
-    line_ending <- "\r\n"
-  } else {
-    line_ending <- "\n"
+write_lines <- function(text, path, line_ending = NULL) {
+  if (is.null(line_ending)) {
+    if (has_windows_le(path)) {
+      line_ending <- "\r\n"
+    } else {
+      line_ending <- "\n"
+    }
   }
 
   # we need to convert any embedded newlines as well

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -12,6 +12,9 @@ write_lines <- function(text, path) {
     line_ending <- "\n"
   }
 
+  # we need to convert any embedded newlines as well
+  text <- gsub("\r?\n", line_ending, text)
+
   path <- file(path, open = "wb")
   base::writeLines(enc2utf8(text), path, sep = line_ending, useBytes = TRUE)
   close(path)

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,7 +80,7 @@ write_if_different <- function(path, contents, check = TRUE) {
   }
 
   contents <- paste0(paste0(contents, collapse = line_ending), line_ending)
-  contents <- gsub("\r?\n", line_ending, contents)
+  contents <- enc2utf8(gsub("\r?\n", line_ending, contents))
   if (same_contents(path, contents)) return(FALSE)
 
   name <- basename(path)
@@ -89,7 +89,7 @@ write_if_different <- function(path, contents, check = TRUE) {
     FALSE
   } else {
     cat(sprintf('Writing %s\n', name))
-    writeBin(charToRaw(enc2utf8(contents)), path)
+    writeBin(charToRaw(contents), path)
     TRUE
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -90,6 +90,9 @@ write_if_different <- function(path, contents, check = TRUE) {
 }
 
 same_contents <- function(path, contents) {
+  if (length(contents) != 1) {
+    stop("Internal roxygen error: `contents` must be character(1)")
+  }
   if (!file.exists(path)) return(FALSE)
 
   text_hash <- digest::digest(contents, serialize = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,6 +73,14 @@ write_if_different <- function(path, contents, check = TRUE) {
     return(FALSE)
   }
 
+  if (has_windows_le(path)) {
+    line_ending <- "\r\n"
+  } else {
+    line_ending <- "\n"
+  }
+
+  contents <- paste0(paste0(contents, collapse = line_ending), line_ending)
+  contents <- gsub("\r?\n", line_ending, contents)
   if (same_contents(path, contents)) return(FALSE)
 
   name <- basename(path)
@@ -81,15 +89,13 @@ write_if_different <- function(path, contents, check = TRUE) {
     FALSE
   } else {
     cat(sprintf('Writing %s\n', name))
-    write_lines(contents, path)
+    writeBin(charToRaw(enc2utf8(contents)), path)
     TRUE
   }
 }
 
 same_contents <- function(path, contents) {
   if (!file.exists(path)) return(FALSE)
-
-  contents <- paste0(paste0(contents, collapse = "\n"), "\n")
 
   text_hash <- digest::digest(contents, serialize = FALSE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,12 +73,7 @@ write_if_different <- function(path, contents, check = TRUE) {
     return(FALSE)
   }
 
-  if (has_windows_le(path)) {
-    line_ending <- "\r\n"
-  } else {
-    line_ending <- "\n"
-  }
-
+  line_ending <- detect_line_ending(path)
   contents <- paste0(paste0(contents, collapse = line_ending), line_ending)
   contents <- enc2utf8(gsub("\r?\n", line_ending, contents))
   if (same_contents(path, contents)) return(FALSE)

--- a/tests/testthat/test-rd.R
+++ b/tests/testthat/test-rd.R
@@ -98,7 +98,7 @@ test_that("write_lines writes unix-style line endings.", {
   path <- test_path("escapes.Rd")
 
   # skip if checked on windows with autocrlf = true
-  skip_if(has_windows_le(path))
+  skip_if(detect_line_ending(path) == "\r\n")
 
   temp_filename <- tempfile()
   old_binary <- readBin(path, "raw", n = file.info(path)$size)

--- a/tests/testthat/test-utils-io.R
+++ b/tests/testthat/test-utils-io.R
@@ -1,4 +1,4 @@
-test_that("has_windows_le works", {
+test_that("detect_line_ending works", {
   # write files with various newlines
   win_nl <- tempfile()
   win_nl_con <- file(win_nl, "wb")
@@ -21,10 +21,10 @@ test_that("has_windows_le works", {
   base::writeLines(c("foo", "bar"), unix_nl_con, sep = "\n")
   close(unix_nl_con)
 
-  expect_true(has_windows_le(win_nl))
-  expect_false(has_windows_le(unix_nl))
-  expect_false(has_windows_le(non_existent_file))
-  expect_false(has_windows_le(empty_file))
+  expect_equal(detect_line_ending(win_nl), "\r\n")
+  expect_equal(detect_line_ending(unix_nl), "\n")
+  expect_equal(detect_line_ending(non_existent_file), "\n")
+  expect_equal(detect_line_ending(empty_file), "\n")
 })
 
 test_that("write_lines writes windows newlines for files with windows newlines, and unix newlines otherwise", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -10,4 +10,43 @@ test_that("nice_name protects against invalid characters", {
   expect_equal(nice_name("[.a"), "sub-.a")
 })
 
+test_that("write_if_different and end of line", {
+  cnt_unix <- c("foo\nbar\nbaz", "foobar")
+  cnt_win  <- c("foo\r\nbar\r\nbaz", "foobar")
+  cnt_mix  <- c("foo\nbar\r\nbaz", "foobar")
 
+  tmp <- tempfile("roxy-", fileext = ".Rd")
+  on.exit(unlink(tmp), add = TRUE)
+
+  # do not change unix le
+  write_lines(cnt_unix, tmp, line_ending = "\n")
+  expect_silent(write_if_different(tmp, cnt_unix, check = FALSE))
+  expect_silent(write_if_different(tmp, cnt_win,  check = FALSE))
+  expect_silent(write_if_different(tmp, cnt_mix,  check = FALSE))
+
+  # do not change windows le
+  write_lines(cnt_win, tmp, line_ending = "\r\n")
+  expect_silent(write_if_different(tmp, cnt_unix, check = FALSE))
+  expect_silent(write_if_different(tmp, cnt_win,  check = FALSE))
+  expect_silent(write_if_different(tmp, cnt_mix,  check = FALSE))
+
+  # change mixed le to windows
+  tmp_win <- tempfile("roxy-", fileext = ".Rd")
+  on.exit(unlink(tmp_win), add = TRUE)
+  write_lines(cnt_win, tmp_win, line_ending = "\r\n")
+
+  # write_lines changes line endings, so we use writeBin to create a file with mixed
+  # line endings
+  raw_mix <- charToRaw(paste0(paste0(cnt_mix, collapse = "\r\n"), "\r\n"))
+  writeBin(raw_mix, tmp)
+  expect_output(write_if_different(tmp, cnt_unix, check = FALSE), "Writing ")
+  expect_identical(readBin(tmp, "raw", 100), readBin(tmp_win, "raw", 100))
+
+  writeBin(raw_mix, tmp)
+  expect_output(write_if_different(tmp, cnt_win, check = FALSE), "Writing ")
+  expect_identical(readBin(tmp, "raw", 100), readBin(tmp_win, "raw", 100))
+
+  writeBin(raw_mix, tmp)
+  expect_output(write_if_different(tmp, cnt_mix, check = FALSE), "Writing ")
+  expect_identical(readBin(tmp, "raw", 100), readBin(tmp_win, "raw", 100))
+})


### PR DESCRIPTION
We need to move the detection of line endings
upstream a bit, to be able to tell if the
newly generated contents is different from the
current one, in `write_if_different()`.

This means that we need to `paste()` the contents
together in `write_if_different()`. Consequently,
we might as well remove the `paste()`-ing from
`same_contents()`, as `write_if_different()` always
calls it with the `paste()`-d contents.

Also, if we `paste()` already upstream, then
we might as well use `writeBin()` to write out
the contents, instead of `write_lines()`, especially
because `write_lines()` would add an extra empty line.
`write_lines()` is still kept, and used in some
code paths, and it can also do EOL-detection,
although this feature is not used currently.

Another benefit of this refactoring is that we
also move `enc2utf8()` upstream, this should clearly
happen before we check if the new contents is
different.

Added test cases as well.

Fixes #989, supersedes #1003.
