### PR TITLE
Fix typo in namespace vignette

### DIFF
--- a/vignettes/namespace.Rmd
+++ b/vignettes/namespace.Rmd
@@ -37,7 +37,7 @@ Use the following guidelines to decide what to export:
   generics will not find the correct method.
   
     If you are providing a method for a generic defined in another package,
-    you must also import that generate.
+    you must also import that generic.
 
 * S4 classes: if you want others to be able to extend your class, `@export` it.
   If you want others to create instances of your class, but not extend it,


### PR DESCRIPTION
This fixes a minor typo in the namespace vignette.