### PR TITLE
Fix object format test case for R 4.x

### DIFF
--- a/tests/testthat/test-object-format-r4.txt
+++ b/tests/testthat/test-object-format-r4.txt
@@ -1,0 +1,15 @@
+> call_to_format(x <- list(a = 1, b = 2))
+[1] "An object of class \\code{list} of length 2."
+
+> call_to_format(x <- ordered(letters[1:5]))
+[1] "An object of class \\code{ordered} (inherits from \\code{factor}) of length 5."
+
+> call_to_format(x <- diag(10))
+[1] "An object of class \\code{matrix} (inherits from \\code{array}) with 10 rows and 10 columns."
+
+> call_to_format(x <- array(1:27, dim = c(3, 3, 3)))
+[1] "An object of class \\code{array} of dimension 3 x 3 x 3."
+
+> call_to_format(x <- data.frame(a = 1, b = 2))
+[1] "An object of class \\code{data.frame} with 1 rows and 2 columns."
+

--- a/tests/testthat/test-object-format.R
+++ b/tests/testthat/test-object-format.R
@@ -1,5 +1,10 @@
 test_that("format has nice defaults for bare vectors", {
-  verify_output(test_path("test-object-format.txt"), {
+  if (getRversion() >= "4.0.0") {
+    txt <- "test-object-format-r4.txt"
+  } else {
+    txt <- "test-object-format.txt"
+  }
+  verify_output(test_path(txt), {
     call_to_format(x <- list(a = 1, b = 2))
     call_to_format(x <- ordered(letters[1:5]))
     call_to_format(x <- diag(10))


### PR DESCRIPTION
Matrices now inherit from "array", so that
is included in the output.

Closes #1052.