### PR TITLE
Fix \figure{} output from md when alternate text is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 
 * Multiple `@format` tags are now combined (#1015).
 
+* roxygen2 now omits empty annotations (alternate text) for figures added
+  via markdown. This caused issues when generating pkgdown web sites
+  (#1051).
+
 # roxygen2 7.0.2
 
 * `\example{}` escaping has been improved (again!) so that special escapes 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -348,7 +348,10 @@ mdxml_link_text <- function(xml_contents, state) {
 mdxml_image = function(xml) {
   dest <- xml_attr(xml, "destination")
   title <- xml_attr(xml, "title")
-  paste0("\\figure{", dest, "}{", title, "}")
+  paste0(
+    "\\figure{", dest, "}",
+    if (nchar(title)) paste0("{", title, "}")
+  )
 }
 
 escape_comment <- function(x) {

--- a/man/markdown_pass1.Rd
+++ b/man/markdown_pass1.Rd
@@ -44,6 +44,6 @@ nrow(mtcars)
 Plots:\if{html}{\out{<div class="r">}}\preformatted{plot(1:10)
 }\if{html}{\out{</div>}}
 
-\figure{test-figure-1.png}{}
+\figure{test-figure-1.png}
 }
 \keyword{internal}


### PR DESCRIPTION
Then we need to leave out the second \figure{} argument,
according to WRE. This fixes pkgdown on roxygen2.

Closes #1051.