### PR TITLE
Keep order of @includeRmd sections

### DIFF
--- a/R/rd-markdown.R
+++ b/R/rd-markdown.R
@@ -123,7 +123,14 @@ format.rd_section_details <- function(x, ...) {
 rd_section_markdown <- function(name, value) {
   # Any additional components are sections
   if (length(value) > 1) {
-    name <- c(name, rep("rawRd", length(value) - 1))
+    titles <- names(value)
+    value <- unname(value)
+
+    name <- c(name, rep("section", length(value) - 1))
+    value <- c(
+      list(value[[1]]),
+      map2(titles[-1], value[-1], ~ list(title = .x, content = .y))
+    )
 
     if (value[[1]] == "") {
       name <- name[-1]

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -570,19 +570,12 @@ test_that("level 1 heading in @details", {
     #' Description.
     #' @details
     #' Leading text goes into details.
-    #' @rawRd
-    #' \\section{This is its own section}{
-    #' \\subsection{Can have a subsection}{
+    #' @section This is its own section:\\subsection{Can have a subsection}{
     #'
     #' Yes.
     #' }
     #'
-    #' }
-    #' @rawRd
-    #' \\section{Another section}{
-    #'
-    #' With text.
-    #' }
+    #' @section Another section:With text.
     #' @name x
     NULL
   "
@@ -635,16 +628,16 @@ test_that("markup in headings", {
   "
   out1 <- roc_proc_text(rd_roclet(), text1)[[1]]
   expect_equal(
-    out1$get_value("rawRd"),
-    paste(
-      sep = "\n",
-      "\\section{Section with \\code{code}}{",
-      "\\subsection{Subsection with \\strong{strong}}{",
-      "",
-      "Yes.",
-      "}",
-      "",
-      "}"
+    out1$get_value("section"),
+    list(
+      title = "Section with \\code{code}",
+      content = paste(
+        sep = "\n",
+        "\\subsection{Subsection with \\strong{strong}}{",
+        "",
+        "Yes.",
+        "}"
       )
+    )
   )
 })


### PR DESCRIPTION
Use 'section' sections for level 1 headings, instead of a 'rawRd' sections.

The return values of the internal `markdown()` and `mdxml_children_to_rd_top()` can now be named vectors, where the names are the section titles. Not super great, but it is was already not very clean to start with.

I'll take another look at this on Monday, and will try to clean up this part a bit. Will also try to address #988 then.

Closes #1032.