### PR TITLE
Fix interactions of dynamic code and fragile tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 (development version)
 
+* roxygen2 now supports inline markdown code and code chunks inside
+  Rd tags. In particular in `\out{}` (#1115).
+
 # roxygen2 7.1.0
 
 ## New features

--- a/tests/testthat/test-markdown-code.R
+++ b/tests/testthat/test-markdown-code.R
@@ -124,3 +124,21 @@ test_that("fence options are used", {
   details <- out1$get_value("details")
   expect_false(grepl("Error", details))
 })
+
+test_that("dynamic code in fragile tags still runs", {
+  out <- markdown("foo \\out{`r 1+1`} bar")
+  expect_equal(out, "foo \\out{2} bar")
+})
+
+test_that("fragile tags in dynamic code are left alone", {
+  out <- markdown("foo `r substr('\\\\out{xxx}', 2, 4)` bar")
+  expect_equal(out, "foo out bar")
+})
+
+test_that("fragile tags in generated code", {
+  out <- markdown("foo `r '\\\\out{*1*}'` bar")
+  expect_equal(out, "foo \\out{*1*} bar")
+
+  expect_silent(out2 <- markdown("foo `r '\\\\out{<span></span>}'` bar"))
+  expect_equal(out2, "foo \\out{<span></span>} bar")
+})

--- a/tests/testthat/testNamespace/DESCRIPTION
+++ b/tests/testthat/testNamespace/DESCRIPTION
@@ -6,4 +6,4 @@ Author: Hadley <hadley@rstudio.com>
 Maintainer: Hadley <hadley@rstudio.com>
 Encoding: UTF-8
 Version: 0.1
-RoxygenNote: 7.0.2.9000
+RoxygenNote: 7.1.0.9000


### PR DESCRIPTION
Before this, we evaluated dynamic after the fragile tags
were removed (set aside temporarily). This is problematic,
because these tags were also removed from within inline
code and code blocks, and more importantly, you could
not reliably return fragile tags from the dynamic code.

After this patch the order is this:
1. Parse the tag as markdown, find the inline code
   and the code blocks, execute them, substitute
   back the result.
2. Set aside the fragile tags, temporarily.
3. Parse as markdown again, generate Rd.
4. Put back the fragile tags.

This is a breaking change in theory, however dynamic
code is relatively recent, and the affected documentation
is somewhat obscure, so we can probably get away with it.
The potentially affected cases are:
* People having dynamic code in fragile tags. E.g.

    #' blah \out{`r expression`} blah

  This will now evaluate the expression.
* People generating fragile tags dynamically. E.g. as in
  the original post of https://github.com/r-lib/roxygen2/issues/1115
  We actually improve this use case with this patch.

Closes #1115.