### PR TITLE
only use safe on.exit

### DIFF
--- a/R/block.R
+++ b/R/block.R
@@ -80,7 +80,7 @@ block_create <- function(tokens, call, srcref) {
   if (is.null(pkgenv)) pkgenv <- baseenv()
   evalenv <- new.env(parent = pkgenv)
   roxy_meta_set("evalenv", evalenv)
-  on.exit(roxy_meta_set("evalenv", NULL), add = TRUE)
+  on.exit(roxy_meta_set("evalenv", NULL), add = TRUE, after = FALSE)
 
   tags <- parse_tags(tokens)
   if (length(tags) == 0) return()

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -342,7 +342,7 @@ mdxml_link_text <- function(xml_contents, state) {
   # markdown_xml(), which then get interpreted as empty strings by
   # xml_text(). So we preserve newlines as spaces.
   inlink <- state$inlink
-  on.exit(state$inlink <- inlink, add = TRUE)
+  on.exit(state$inlink <- inlink, add = TRUE, after = FALSE)
   state$inlink <- TRUE
 
   text <- map_chr(xml_contents, mdxml_node_to_rd, state)

--- a/R/parse.R
+++ b/R/parse.R
@@ -55,7 +55,7 @@ parse_text <- function(text, env = env_file(file)) {
 
   file <- tempfile()
   write_lines(text, file)
-  on.exit(unlink(file))
+  on.exit(unlink(file), add = TRUE, after = FALSE)
 
   blocks <- parse_file(file, env = env, srcref_path = "<text>")
   blocks <- order_blocks(blocks)

--- a/R/rd-find-link-files.R
+++ b/R/rd-find-link-files.R
@@ -45,7 +45,7 @@ find_topic_filename <- function(pkg, topic, tag = NULL) {
 find_topic_in_package <- function(pkg, topic) {
   # This is needed because we have the escaped text here, and parse_Rd will
   # un-escape it properly.
-  on.exit(close(con), add = TRUE)
+  on.exit(close(con), add = TRUE, after = FALSE)
   con <- textConnection(topic)
   raw_topic <- str_trim(tools::parse_Rd(con)[[1]][1])
   basename(utils::help((raw_topic), (pkg))[1])

--- a/R/rd-include-rmd.R
+++ b/R/rd-include-rmd.R
@@ -21,7 +21,7 @@ roxy_tag_rd.roxy_tag_includeRmd <- function(x, base_path, env) {
 
   wd <- getwd()
   setwd(base_path)
-  on.exit(setwd(wd), add = TRUE)
+  on.exit(setwd(wd), add = TRUE, after = FALSE)
 
   # This will create an absolute path
   rmd <- normalizePath(rmd)

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -129,7 +129,7 @@ roc_proc_text <- function(roclet, input) {
 
   file <- tempfile()
   write_lines(input, file)
-  on.exit(unlink(file))
+  on.exit(unlink(file), add = TRUE, after = FALSE)
 
   env <- env_file(file)
   blocks <- parse_text(input, env = env)

--- a/R/roxygenize.R
+++ b/R/roxygenize.R
@@ -61,7 +61,7 @@ roxygenize <- function(package.dir = ".",
   load_code <- find_load_strategy(load_code)
   env <- load_code(base_path)
   roxy_meta_set("env", env)
-  on.exit(roxy_meta_set("env", NULL), add = TRUE)
+  on.exit(roxy_meta_set("env", NULL), add = TRUE, after = FALSE)
 
   # Tokenise each file
   blocks <- parse_package(base_path, env = NULL)

--- a/R/util-locale.R
+++ b/R/util-locale.R
@@ -6,7 +6,7 @@ set_collate <- function(locale) {
 
 with_collate <- function(locale, code) {
   old <- set_collate(locale)
-  on.exit(set_collate(old))
+  on.exit(set_collate(old), add = TRUE, after = FALSE)
 
   force(code)
 }

--- a/R/utils-rd.R
+++ b/R/utils-rd.R
@@ -114,7 +114,7 @@ tweak_links <- function(x, package) {
 
 parse_rd <- function(x) {
   con <- textConnection(x)
-  on.exit(close(con), add = TRUE)
+  on.exit(close(con), add = TRUE, after = FALSE)
 
   tryCatch(
     tools::parse_Rd(con, fragment = TRUE, encoding = "UTF-8"),

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -59,7 +59,7 @@ vign_update_all <- function(pkg_path) {
 
     make <- Sys.getenv("MAKE", "make")
     old <- setwd(vig_path)
-    on.exit(setwd(old), add = TRUE)
+    on.exit(setwd(old), add = TRUE, after = FALSE)
 
     system(make)
   } else {

--- a/tests/testthat/test-collate.R
+++ b/tests/testthat/test-collate.R
@@ -18,7 +18,7 @@ test_that("collation as expected", {
 
 test_that("Collate field unchanged when no @includes", {
   test_pkg <- temp_copy_pkg('testCollateNoIncludes')
-  on.exit(unlink(test_pkg, recursive = TRUE))
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   old_desc <- read.description(file.path(test_pkg, "DESCRIPTION"))
   update_collate(test_pkg)
@@ -35,7 +35,11 @@ test_that("DESCRIPTION file is re-written only if collate changes", {
 
   # make backup copy of incomplete DESCRIPTION file (restored on exit)
   file.copy(desc_path, tmp <- tempfile())
-  on.exit( file.copy(tmp, desc_path, overwrite = TRUE), add = TRUE)
+  on.exit(
+    file.copy(tmp, desc_path, overwrite = TRUE),
+    add = TRUE,
+    after = FALSE
+  )
 
   # load package: this should update the DESCRIPTION file (warning)
   expect_output(update_collate(pkg_path), "Updating collate directive", info = "update_collate on incomplete package: DESCRIPTION file is updated")

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -439,7 +439,7 @@ test_that("markup in link text", {
 
 test_that("linking to self is unqualified", {
   old <- roxy_meta_set("current_package", "myself")
-  on.exit(roxy_meta_set("current_package", old), add = TRUE)
+  on.exit(roxy_meta_set("current_package", old), add = TRUE, after = FALSE)
   rd <- markdown("foo [myself::fun()] and [myself::obj] bar")
   expect_equal(
     rd,

--- a/tests/testthat/test-markdown-state.R
+++ b/tests/testthat/test-markdown-state.R
@@ -22,7 +22,7 @@ test_that("turning on/off markdown globally", {
   )
 
   old <- roxy_meta_set("markdown", TRUE)
-  on.exit(roxy_meta_set("markdown", old))
+  on.exit(roxy_meta_set("markdown", old), add = TRUE, after = FALSE)
   out1 <- roc_proc_text(rd_roclet(), "
     #' Title
     #'
@@ -58,7 +58,7 @@ test_that("turning on/off markdown locally", {
   )
 
   old <- roxy_meta_set("markdown", TRUE)
-  on.exit(roxy_meta_set("markdown", old))
+  on.exit(roxy_meta_set("markdown", old), add = TRUE, after = FALSE)
   out1 <- roc_proc_text(rd_roclet(), "
     #' Title
     #'
@@ -101,7 +101,7 @@ test_that("warning for both @md and @noMd", {
   )
 
   old <- roxy_meta_set("markdown", TRUE)
-  on.exit(roxy_meta_set("markdown", old))
+  on.exit(roxy_meta_set("markdown", old), add = TRUE, after = FALSE)
   expect_warning(
     out1 <- roc_proc_text(rd_roclet(), "
       #' Title

--- a/tests/testthat/test-object-from-call.R
+++ b/tests/testthat/test-object-from-call.R
@@ -31,7 +31,7 @@ test_that("can document eager data", {
   skip_if_not_installed("devtools")
 
   test_pkg <- temp_copy_pkg('testEagerData')
-  on.exit(unlink(test_pkg, recursive = TRUE))
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   expect_output(devtools::document(test_pkg), "a[.]Rd")
   expect_true(file.exists(file.path(test_pkg, "man", "a.Rd")))
@@ -41,7 +41,7 @@ test_that("can document lazy data", {
   skip_if_not_installed("devtools")
 
   test_pkg <- temp_copy_pkg('testLazyData')
-  on.exit(unlink(test_pkg, recursive = TRUE))
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   expect_output(devtools::document(test_pkg), "a[.]Rd")
   expect_true(file.exists(file.path(test_pkg, "man", "a.Rd")))

--- a/tests/testthat/test-package_files.R
+++ b/tests/testthat/test-package_files.R
@@ -7,7 +7,7 @@ test_that("respects order in Collate (#790)", {
 
 test_that("roxygen ignores files with matching pattern in .Rbuildignore", {
   test_pkg <- temp_copy_pkg(test_path("testRbuildignore"))
-  on.exit(unlink(test_pkg, recursive = TRUE))
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   expect_equal(basename(package_files(test_pkg)), c("a.R", "ignore_me.R"))
 
@@ -17,7 +17,7 @@ test_that("roxygen ignores files with matching pattern in .Rbuildignore", {
 
 test_that("roxygen works with empty lines in .Rbuildignore", {
   test_pkg <- temp_copy_pkg(test_path("testRbuildignore"))
-  on.exit(unlink(test_pkg, recursive = TRUE))
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   write_lines("^R/ignore_me.R$\n\n.nonexistentfile", file.path(test_pkg, ".Rbuildignore"))
   expect_equal(basename(package_files(test_pkg)), "a.R")

--- a/tests/testthat/test-rd-family.R
+++ b/tests/testthat/test-rd-family.R
@@ -111,7 +111,7 @@ test_that("family also included in concepts", {
 test_that("custom family prefixes can be set", {
 
   owd <- setwd(tempdir())
-  on.exit(setwd(owd), add = TRUE)
+  on.exit(setwd(owd), add = TRUE, after = FALSE)
 
   roxy_meta_set("rd_family_title", list(a = "Custom prefix: "))
   out <- roc_proc_text(rd_roclet(), "

--- a/tests/testthat/test-rd-includermd.R
+++ b/tests/testthat/test-rd-includermd.R
@@ -2,7 +2,7 @@ test_that("markdown file can be included", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat("List:\n\n* item1\n* item2\n\nInline `code` and _emphasis_.\n",
       file = tmp)
   rox <- sprintf("
@@ -32,7 +32,7 @@ test_that("markdown with headers", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "Text at the front",
     "",
@@ -69,7 +69,7 @@ test_that("subsection within details", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "Text at the front",
     "",
@@ -94,7 +94,7 @@ test_that("links to functions", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "This is a link: [roxygenize()].",
     "Another one: [stringr::str_length()]"
@@ -116,7 +116,7 @@ test_that("links to functions, with anchors", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "This is a link: [roxygenize()].",
     "Another one: [stringr::str_length()]",
@@ -139,7 +139,7 @@ test_that("links to functions, with anchors", {
 
 test_that("empty Rmd", {
   tmp <- tempfile()
-  on.exit(unlink(tmp), add = TRUE)
+  on.exit(unlink(tmp), add = TRUE, after = FALSE)
   tag <- roxy_tag("includeRmd", tmp)
 
   cat("", sep = "", file = tmp)
@@ -156,7 +156,7 @@ test_that("inline html", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "Text at the front",
     "",
@@ -183,7 +183,7 @@ test_that("html block", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat(sep = "\n", file = tmp,
     "Text at the front",
     "",
@@ -208,7 +208,7 @@ test_that("include as another section", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat("List:\n\n* item1\n* item2\n\nInline `code` and _emphasis_.\n",
       file = tmp)
   rox <- sprintf("
@@ -238,7 +238,7 @@ test_that("order of sections is correct", {
   skip_if_not(rmarkdown::pandoc_available())
 
   tmp <- tempfile(fileext = ".md")
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE, after = FALSE)
   cat("# Rmd\n\nList:\n\n* item1\n* item2\n\nInline `code` and _emphasis_.\n",
       file = tmp)
   rox <- sprintf("

--- a/tests/testthat/test-rd-r6.R
+++ b/tests/testthat/test-rd-r6.R
@@ -318,7 +318,7 @@ test_that("warning if no method comes after the docs", {
 test_that("integration test", {
 
   wd <- getwd()
-  on.exit(setwd(wd), add = TRUE)
+  on.exit(setwd(wd), add = TRUE, after = FALSE)
   setwd(test_path())
 
   env <- new.env(parent = asNamespace("roxygen2"))
@@ -348,7 +348,7 @@ test_that("integration test", {
   )
 
   tmp <- tempfile()
-  on.exit(unlink(tmp), add = TRUE)
+  on.exit(unlink(tmp), add = TRUE, after = FALSE)
   for (n in names(res)) {
     path <- test_path(paste0("roxygen-block-3-", n))
     verify_output(path, res[[n]])
@@ -371,7 +371,7 @@ test_that("r6 option", {
       )
     )"
   old <- roxy_meta_get("r6")
-  on.exit(roxy_meta_set("r6", old), add = TRUE)
+  on.exit(roxy_meta_set("r6", old), add = TRUE, after = FALSE)
   roxy_meta_set("r6", FALSE)
 
   expect_silent(

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -296,7 +296,7 @@ test_that("new wrapping style doesn't change unexpectedly", {
 
 test_that("old wrapping style doesn't change unexpectedly", {
   old <- roxy_meta_set("old_usage", TRUE)
-  on.exit(roxy_meta_set("old_usage", old))
+  on.exit(roxy_meta_set("old_usage", old), add = TRUE, after = FALSE)
 
   expect_known_output(file = test_path("test-object-usage-wrap-old.txt"), {
     cat(call_to_usage({
@@ -339,5 +339,3 @@ test_that("old wrapping style doesn't change unexpectedly", {
     }), "\n\n")
   })
 })
-
-

--- a/tests/testthat/test-rd.R
+++ b/tests/testthat/test-rd.R
@@ -142,7 +142,7 @@ test_that("@details NULL", {
 
 test_that("can generate nonASCII document", {
   test_pkg <- temp_copy_pkg(test_path('testNonASCII'))
-  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE)
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   expect_output(roxygenise(test_pkg, roclets = "rd"), "printChineseMsg[.]Rd")
 
@@ -159,7 +159,7 @@ test_that("can generate nonASCII document", {
 
 test_that("unicode escapes are ok", {
   test_pkg <- temp_copy_pkg(test_path('testUtf8Escape'))
-  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE)
+  on.exit(unlink(test_pkg, recursive = TRUE), add = TRUE, after = FALSE)
 
   expect_output(roxygenise(test_pkg, roclets = "rd"), "a[.]Rd")
 
@@ -183,7 +183,7 @@ test_that("write_lines writes unix-style line endings.", {
   old_binary <- readBin(path, "raw", n = file.info(path)$size)
   old_text <- read_lines(path)
   write_lines(old_text, temp_filename)
-  on.exit(unlink(temp_filename), add = TRUE)
+  on.exit(unlink(temp_filename), add = TRUE, after = FALSE)
   new_binary <- readBin(temp_filename, "raw", n = file.info(temp_filename)$size)
   expect_identical(new_binary, old_binary)
 })

--- a/tests/testthat/test-utils-io.R
+++ b/tests/testthat/test-utils-io.R
@@ -11,9 +11,11 @@ test_that("detect_line_ending works", {
   empty_file <- tempfile()
   file.create(empty_file)
 
-  on.exit({
-    unlink(c(win_nl, unix_nl, empty_file))
-  })
+  on.exit(
+    unlink(c(win_nl, unix_nl, empty_file)),
+    add = TRUE,
+    after = FALSE
+  )
 
   base::writeLines(c("foo", "bar"), win_nl_con, sep = "\r\n")
   close(win_nl_con)
@@ -40,9 +42,11 @@ test_that("write_lines writes windows newlines for files with windows newlines, 
   empty_file <- tempfile()
   file.create(empty_file)
 
-  on.exit({
-    unlink(c(win_nl, unix_nl, empty_file, non_existent_file))
-  })
+  on.exit(
+    unlink(c(win_nl, unix_nl, empty_file, non_existent_file)),
+    add = TRUE,
+    after = FALSE
+  )
 
   base::writeLines(c("foo", "bar"), win_nl_con, sep = "\r\n")
   close(win_nl_con)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -16,7 +16,7 @@ test_that("write_if_different and end of line", {
   cnt_mix  <- c("foo\nbar\r\nbaz", "foobar")
 
   tmp <- tempfile("roxy-", fileext = ".Rd")
-  on.exit(unlink(tmp), add = TRUE)
+  on.exit(unlink(tmp), add = TRUE, after = FALSE)
 
   # do not change unix le
   write_lines(cnt_unix, tmp, line_ending = "\n")
@@ -32,7 +32,7 @@ test_that("write_if_different and end of line", {
 
   # change mixed le to windows
   tmp_win <- tempfile("roxy-", fileext = ".Rd")
-  on.exit(unlink(tmp_win), add = TRUE)
+  on.exit(unlink(tmp_win), add = TRUE, after = FALSE)
   write_lines(cnt_win, tmp_win, line_ending = "\r\n")
 
   # write_lines changes line endings, so we use writeBin to create a file with mixed


### PR DESCRIPTION
As recommended by [testthat](https://testthat.r-lib.org/articles/test-fixtures.html), this PR adds extra arguments to  all `on.exit()`s .

> You should always call it with add = TRUE and after = FALSE. 
> These ensure that the call is added to the list of deferred tasks (instead of replaces) and is added to the front of the stack (not the back, so that cleanup occurs in reverse order to setup). 
> These arguments only matter if you’re using multiple on.exit() calls, but it’s a good habit to always use them to avoid potential problems down the road.

I tried this as a potential fix for #1189 (it didn't help), but maybe it'll still be worthwhile for peace of mind.

Downside: this adds verbosity and may often be unnecessary.

A better solution of test fixtures would probably use `withr::defer()` and existing `withr::with_*()`.
But withr isn't in the dependencies for roxygen2, so maybe this is a medium term improvement.

I think this also only works in >= R 3.5 (the `after` argument is new, I think).
Not sure what the backwards compatibility goal for roxygen2 is.