### PR TITLE
let base r manage cons in expect_

### DIFF
--- a/tests/testthat/test-utils-io.R
+++ b/tests/testthat/test-utils-io.R
@@ -51,14 +51,14 @@ test_that("write_lines writes windows newlines for files with windows newlines, 
   close(unix_nl_con)
 
   write_lines("baz", win_nl)
-  expect_equal(readChar(file(win_nl, "rb"), 100), "baz\r\n")
+  expect_equal(readChar(win_nl, 100), "baz\r\n")
 
   write_lines("baz", unix_nl)
-  expect_equal(readChar(file(unix_nl, "rb"), 100), "baz\n")
+  expect_equal(readChar(unix_nl, 100), "baz\n")
 
   write_lines("baz", non_existent_file)
-  expect_equal(readChar(file(non_existent_file, "rb"), 100), "baz\n")
+  expect_equal(readChar(non_existent_file, 100), "baz\n")
 
   write_lines("baz", empty_file)
-  expect_equal(readChar(file(empty_file, "rb"), 100), "baz\n")
+  expect_equal(readChar(empty_file, 100), "baz\n")
 })


### PR DESCRIPTION
In several places in the tests, file connections are currently managed "by hand", some of which may remain unbalanced at the end of a test run.

Accepting strings, instead of connections inside `expect_equal()` appears to be smallest possible change to resolve the warnings in #1189. So this closes #1189.

The docs to [`readChar()`](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/readChar) state that `con` can be:

> A connection object, or a character string naming a file, or a raw vector.

So it would seem to be unnecessary for the test to create a connection with `file()` here.

But I may be ignorant about something important here 😬.
@jonthegeek can you advise whether there is a reason to manually manage the connection, rather than relying letting `readChar()` take care of them?


