### PR TITLE
let base r manage cons everywhere in tests (superset of #1191)

### DIFF
--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -9,9 +9,7 @@ write_lines <- function(text, path, line_ending = detect_line_ending(path)) {
   # we need to convert any embedded newlines as well
   text <- gsub("\r?\n", line_ending, text)
 
-  path <- file(path, open = "wb")
   base::writeLines(enc2utf8(text), path, sep = line_ending, useBytes = TRUE)
-  close(path)
 }
 
 detect_line_ending <- function(path) {

--- a/tests/testthat/test-utils-io.R
+++ b/tests/testthat/test-utils-io.R
@@ -51,14 +51,14 @@ test_that("write_lines writes windows newlines for files with windows newlines, 
   close(unix_nl_con)
 
   write_lines("baz", win_nl)
-  expect_equal(readChar(file(win_nl, "rb"), 100), "baz\r\n")
+  expect_equal(readChar(win_nl, 100), "baz\r\n")
 
   write_lines("baz", unix_nl)
-  expect_equal(readChar(file(unix_nl, "rb"), 100), "baz\n")
+  expect_equal(readChar(unix_nl, 100), "baz\n")
 
   write_lines("baz", non_existent_file)
-  expect_equal(readChar(file(non_existent_file, "rb"), 100), "baz\n")
+  expect_equal(readChar(non_existent_file, 100), "baz\n")
 
   write_lines("baz", empty_file)
-  expect_equal(readChar(file(empty_file, "rb"), 100), "baz\n")
+  expect_equal(readChar(empty_file, 100), "baz\n")
 })

--- a/tests/testthat/test-utils-io.R
+++ b/tests/testthat/test-utils-io.R
@@ -1,10 +1,8 @@
 test_that("detect_line_ending works", {
   # write files with various newlines
   win_nl <- tempfile()
-  win_nl_con <- file(win_nl, "wb")
 
   unix_nl <- tempfile()
-  unix_nl_con <- file(unix_nl, "wb")
 
   non_existent_file <- tempfile()
 
@@ -15,11 +13,9 @@ test_that("detect_line_ending works", {
     unlink(c(win_nl, unix_nl, empty_file))
   })
 
-  base::writeLines(c("foo", "bar"), win_nl_con, sep = "\r\n")
-  close(win_nl_con)
+  base::writeLines(c("foo", "bar"), win_nl, sep = "\r\n")
 
-  base::writeLines(c("foo", "bar"), unix_nl_con, sep = "\n")
-  close(unix_nl_con)
+  base::writeLines(c("foo", "bar"), unix_nl, sep = "\n")
 
   expect_equal(detect_line_ending(win_nl), "\r\n")
   expect_equal(detect_line_ending(unix_nl), "\n")
@@ -30,25 +26,20 @@ test_that("detect_line_ending works", {
 test_that("write_lines writes windows newlines for files with windows newlines, and unix newlines otherwise", {
   # write files with various newlines
   win_nl <- tempfile()
-  win_nl_con <- file(win_nl, "wb")
 
   unix_nl <- tempfile()
-  unix_nl_con <- file(unix_nl, "wb")
 
   non_existent_file <- tempfile()
 
   empty_file <- tempfile()
-  file.create(empty_file)
 
   on.exit({
     unlink(c(win_nl, unix_nl, empty_file, non_existent_file))
   })
 
-  base::writeLines(c("foo", "bar"), win_nl_con, sep = "\r\n")
-  close(win_nl_con)
+  base::writeLines(c("foo", "bar"), win_nl, sep = "\r\n")
 
-  base::writeLines(c("foo", "bar"), unix_nl_con, sep = "\n")
-  close(unix_nl_con)
+  base::writeLines(c("foo", "bar"), unix_nl, sep = "\n")
 
   write_lines("baz", win_nl)
   expect_equal(readChar(win_nl, 100), "baz\r\n")


### PR DESCRIPTION
this is a superset of #1191, reverting to base R management of connections everywhere in the tests.

#1191 does this only where it appears to be related to the spurious warnings in #1189. This also closes #1189.

I think under some circumstances we can end up with unbalanced connections in the current test, and we'd need some more `on.exit(close(foo))` (or, preferably, `withr::with_connection()`) to clean them up.

Instead of dealing with that, I wondered whether we can just let base R's default in `readLines()` and friends deal with the connections instead.
But I might be missing something.

@jonthegeek could you advise for this superset, too, whether there it is ok to let R deal with the cons?