### PR TITLE
Fix suggestion for overriding the default load strategy.

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -25,7 +25,7 @@
 #' `installed` strategies:
 #'
 #' ```
-#' RoxygenNote: list(load = "source")
+#' Roxygen: list(load = "source")
 #' ```
 #' @name load
 #' @param path Path to source package

--- a/man/load.Rd
+++ b/man/load.Rd
@@ -37,6 +37,6 @@ outside of roxygen2.
 
 You can change the default strategy for your function with roxygen2 \code{load}
 option. Override the default off \code{pkgload} to use the \code{source} or
-\code{installed} strategies:\preformatted{RoxygenNote: list(load = "source")
+\code{installed} strategies:\preformatted{Roxygen: list(load = "source")
 }
 }


### PR DESCRIPTION
The man page for `?load` states that one could add `RoxygenNote: list(load = "source")` to select a different load strategy, but this won't work, as it should say `Roxygen` instead.