### PR TITLE
Match div class to pandoc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # roxygen2 (development version)
 
+* Code blocks with language now add `sourceCode` to the generated div; this
+  makes syntax highlighting more consistent across 
+  downlit/pandoc/knitr/roxygen2.
+
 * Percent signs in markdown link targets, e.g. `[text](https://foo/ba%20r)`
   are now handled correctly (#1209).
 

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -256,7 +256,7 @@ mdxml_code_block <- function(xml, state) {
   info <- xml_attr(xml, "info")[1]
   if (is.na(info) || nchar(info[1]) == 0) info <- NA_character_
   paste0(
-    if (!is.na(info)) paste0("\\if{html}{\\out{<div class=\"", info, "\">}}"),
+    if (!is.na(info)) paste0("\\if{html}{\\out{<div class=\"sourceCode ", info, "\">}}"),
     "\\preformatted{",
     escape_verb(xml_text(xml)),
     "}",

--- a/tests/testthat/test-markdown.R
+++ b/tests/testthat/test-markdown.R
@@ -65,7 +65,7 @@ test_that("code block with language creates HTML tag", {
     #'
     #' Description
     #'
-    #' Details with a code block:\\if{html}{\\out{<div class=\"r\">}}\\preformatted{x <- 1:10 \\%>\\%
+    #' Details with a code block:\\if{html}{\\out{<div class=\"sourceCode r\">}}\\preformatted{x <- 1:10 \\%>\\%
     #'   multiply_by(10) \\%>\\%
     #'   add(42)
     #' }\\if{html}{\\out{</div>}}


### PR DESCRIPTION
This makes pkgdown/downlit code simpler since we can assume a more consistent structure across different ways that code blocks are generated.