### PR TITLE
Clarify export for S3 Methods

### DIFF
--- a/vignettes/namespace.Rmd
+++ b/vignettes/namespace.Rmd
@@ -32,7 +32,7 @@ Use the following guidelines to decide what to export:
 * S3 generics: the generic is a function so `@export` if you want it to
   be usable outside the package
 
-* S3 methods: every S3 method _must_ be exported, even if the generic is not.
+* S3 methods: every S3 method _must_ use `@export`, even if the generic does not.
   Otherwise the S3 method table will not be generated correctly and internal
   generics will not find the correct method.
   


### PR DESCRIPTION
I think this is what you mean. At least it seems that when roxygen correctly identifies an S3 method it does not `export()` it in the NAMESPACE file, it only uses the `S3method()` call/directive.

I guess 'export' is overloaded. There's export within the roxygen context, but also within the NAMESPACE file. These things mostly align but sometimes don't. See also: https://github.com/r-lib/roxygen2/issues/1173