### PR TITLE
replace \url{} with \doi{} in package Rd when linking to DOI

### DIFF
--- a/R/object-package.R
+++ b/R/object-package.R
@@ -1,6 +1,7 @@
 package_seealso <- function(desc) {
   if (!is.null(desc$URL)) {
     links <- paste0("\\url{", strsplit(desc$URL, ",\\s+")[[1]], "}")
+    links <- gsub("\\url\\{https://doi.org/", "\\doi{", links)
   } else {
     links <- character()
   }


### PR DESCRIPTION
fixes #1296