### PR TITLE
Adapt `github_document()` format for `@includeRmd`

### DIFF
--- a/R/rd-include-rmd.R
+++ b/R/rd-include-rmd.R
@@ -45,7 +45,7 @@ roxy_tag_rd.roxy_tag_includeRmd <- function(x, base_path, env) {
 
   rmarkdown::render(
     rmd_path,
-    output_format = rmarkdown::github_document(),
+    output_format = rmarkdown::github_document(html_preview = FALSE),
     output_file = md_path,
     quiet = TRUE,
     envir = new_environment(parent = global_env())


### PR DESCRIPTION
This PR is in relation to https://github.com/rstudio/rmarkdown/issues/2331 

I believe the issue could be from the fact that `github_document()` is unnecessary  rendering a HTML self_contained document. `html_preview = FALSE` should be set in the case of `@includeRmd` usage

There may be other adjustment needed so I am creating this as a draft for now until this is tested and sorted out. 