### PR TITLE
Correctly deactivate math support in Rmd for `@includeRmd` with math

### DIFF
--- a/R/rd-include-rmd.R
+++ b/R/rd-include-rmd.R
@@ -45,9 +45,10 @@ roxy_tag_rd.roxy_tag_includeRmd <- function(x, base_path, env) {
 
   rmarkdown::render(
     rmd_path,
-    output_format = rmarkdown::github_document(html_preview = FALSE),
-    output_options = list(
-      if (packageVersion("rmarkdown") >= "2.12") math_method = NULL
+    output_format = "github_document",
+    output_options = c(
+      list(html_preview = FALSE),
+      if (packageVersion("rmarkdown") >= "2.12") list(math_method = NULL)
     ),
     output_file = md_path,
     quiet = TRUE,


### PR DESCRIPTION
This follows up on #1304 to fix https://github.com/rstudio/rmarkdown/issues/2331

This will now correctly modify option to `rmarkdown::github_document()` conditionnaly. I messed up my test last time but now this work as expected.

Tested by: 

* Cloning this project: https://github.com/EmilHvitfeldt/codecogsreprex
* Installing this PR
* running `devtools::document()`

This produce what is explained in the comment in previous PR: https://github.com/r-lib/roxygen2/pull/1304#issuecomment-1069282142

This in markdown
````markdown
$$
\eta_{i} = (\beta_0 + b_{0i}) + \beta_1x_{i1}
$$ 
````

will produce this in Rd file 
````
\emph{η}\if{html}{\out{<sub>}}\emph{i}\if{html}{\out{</sub>}} = (\emph{β}\if{html}{\out{<sub>}}0\if{html}{\out{</sub>}}+\emph{b}\if{html}{\out{<sub>}}0\emph{i}\if{html}{\out{</sub>}}) + \emph{β}\if{html}{\out{<sub>}}1\if{html}{\out{</sub>}}\emph{x}\if{html}{\out{<sub>}}\emph{i}1\if{html}{\out{</sub>}}
````

as Pandoc will convert this math using Plain text. Complex LaTeX math won't work in github document output as pandoc will produce this 
````sh
$ echo "$\frac{1}{2}$" | pandoc -t gfm
[WARNING] Could not convert TeX math \frac{1}{2}, rendering as TeX
$\\frac{1}{2}$
````

@EmilHvitfeldt can you confirm this time  this PR work on your projects ? Thank you ! 

@hadley I am trying to add test so that change on math in included Rmd can be detected
