### PR TITLE
Preserve NAMESPACE during pre-processing pass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ Suggests:
     R.methodsS3,
     R.oo,
     rmarkdown,
-    testthat (>= 3.1.2)
+    testthat (>= 3.1.2),
+    withr
 LinkingTo: 
     cpp11
 VignetteBuilder: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # roxygen2 (development version)
 
+* The NAMESPACE roclet now preserves all existing non-import directives during
+  it's first pre-processing pass. This eliminates the "NAMESPACE has changed"
+  messages and reduces the incidence of namespace borking (#1254).
+
 * Add support for inheriting 'note' fields via `@inherit pkg::fun note` (@pat-s, #1218)
 
 * Problems with the first tag in each block are now reported with the

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -39,8 +39,8 @@ roclet_preprocess.roclet_namespace <- function(x, blocks, base_path) {
     return(x)
   }
 
-  lines <- sort_c(c(lines, namespace_exports(NAMESPACE)))
-  results <- c(made_by("#"), lines)
+  lines <- c(lines, namespace_exports(NAMESPACE))
+  results <- c(made_by("#"), sort_c(unique(lines)))
   write_if_different(NAMESPACE, results, check = TRUE)
 
   invisible(x)

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -39,6 +39,7 @@ roclet_preprocess.roclet_namespace <- function(x, blocks, base_path) {
     return(x)
   }
 
+  lines <- sort_c(c(lines, namespace_exports(NAMESPACE)))
   results <- c(made_by("#"), lines)
   write_if_different(NAMESPACE, results, check = TRUE)
 
@@ -289,4 +290,15 @@ one_per_line <- function(name, x) {
 }
 repeat_first <- function(name, x) {
   paste0(name, "(", auto_quote(x[1]), ",", auto_quote(x[-1]), ")")
+}
+
+namespace_exports <- function(path) {
+  if (!file.exists(path)) {
+    return(character())
+  }
+
+  parsed <- parse(path, keep.source = TRUE)
+  is_import <- function(x) is_call(x, c("import", "importFrom", "importClassesFrom", "importMethodsFrom", "useDynLib"))
+  export_lines <- attr(parsed, "srcref")[!map_lgl(parsed, is_import)]
+  unlist(lapply(export_lines, as.character))
 }

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -332,3 +332,24 @@ test_that("auto_quote behaves as needed", {
   expect_equal(auto_quote("if"), '"if"') # quotes non-syntactic
   expect_equal(auto_quote("'if'"), "'if'") # unless already quoted
 })
+
+test_that("can extract non-imports from namespace preserving source", {
+  path <- withr::local_tempfile(lines = c(
+    "export(x)",
+    "import(y)"
+  ))
+  expect_equal(namespace_exports(path), "export(x)")
+
+  path <- withr::local_tempfile(lines = "export(x, y, z)")
+  expect_equal(namespace_exports(path), "export(x, y, z)")
+
+  lines <- c(
+    "if (TRUE) {",
+    "  import(x, y, z)",
+    "}",
+    "import(a)",
+    "export(b)"
+  )
+  path <- withr::local_tempfile(lines = lines)
+  expect_equal(namespace_exports(path), lines[c(1:3, 5)])
+})


### PR DESCRIPTION
Now preserves all non-import directives.

Fixes #1254