### PR TITLE
Autolink url from package DESCRIPTION when using `"_PACKAGE"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 (development version)
 
+* DOIs, arXiv links, and urls in the `Description` field of the `DESCRIPTION`
+  are now converted to the appropriate Rd markup (@dieghernan, #1265, #1164).
+
 * DOIs in the `URL` field of the `DESCRIPTION` are now converted to Rd's special
   `\doi{}` tag (@ThierryO, #1296).
 

--- a/R/object-defaults.R
+++ b/R/object-defaults.R
@@ -41,7 +41,7 @@ object_defaults.package <- function(x) {
   desc <- x$value$desc
 
   description <- as.character(desc$Description)
-  description <- package_description_urls(description)
+  description <- package_url_parse(description)
   logo_path <- file.path(x$value$path, "man", "figures", "logo.png")
   if (file.exists(logo_path)) {
     fig <- "\\if{html}{\\figure{logo.png}{options: align='right' alt='logo' width='120'}}"

--- a/R/object-defaults.R
+++ b/R/object-defaults.R
@@ -41,6 +41,7 @@ object_defaults.package <- function(x) {
   desc <- x$value$desc
 
   description <- as.character(desc$Description)
+  description <- package_description_urls(description)
   logo_path <- file.path(x$value$path, "man", "figures", "logo.png")
   if (file.exists(logo_path)) {
     fig <- "\\if{html}{\\figure{logo.png}{options: align='right' alt='logo' width='120'}}"

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -379,18 +379,13 @@ package_url_parse <- function(x) {
   # <doi:XX.XXX> -> \doi{XX.XXX} to avoid CRAN Notes, etc.
   x <- str_replace_all(x, "<(doi|DOI):(.*?)>", function(match) {
     match <- str_remove_all(match, "^<(doi|DOI):|>$")
-    paste0("\\doi{", URLdecode(match), "}")
+    paste0("\\doi{", rd_url_decode(match), "}")
   })
 
   # <http:XX.XXX> -> \url{http:XX.XXX}
   x <- str_replace_all(x, "<(http|https):\\/\\/(.*?)>", function(match) {
     match <- str_remove_all(match, "^<|>$")
-    match <- URLdecode(match)
-    # Additionally, encode just the spaces (CRAN Error if not) and mask the %
-    match <- str_replace_all(match, " ", "%20")
-    match <- str_replace_all(match, "([%{}])", "\\$1")
-
-    paste0("\\url{", match, "}")
+    paste0("\\url{", rd_url_decode(match), "}")
   })
 
   # <arxiv:XXX> -> \href{https://arxiv.org/abs/XXX}{arXiv:XXX}
@@ -403,8 +398,21 @@ package_url_parse <- function(x) {
     # Extract arxiv id, split by space
     arxiv_id <- str_split_fixed(match, " ", n = 2)[, 1]
 
-    paste0("\\href{https://arxiv.org/abs/", arxiv_id, "}{arXiv:", match, "}")
+    paste0("\\href{https://arxiv.org/abs/", rd_url_decode(arxiv_id), "}{arXiv:", match, "}")
   })
 
+  x
+}
+
+rd_url_decode <- function(x) {
+  # From R-exts:
+  # > Note that RFC3986-encoded URLs (e.g. using ‘%28VS.85%29’ in place of
+  # > ‘(VS.85)’) may not work correctly in versions of R before 3.1.3 and
+  # > are best avoided --- use URLdecode() to decode them.
+  x <- URLdecode(x)
+  # except for spaces
+  x <- str_replace_all(x, " ", "%20")
+  # and escape
+  x <- str_replace_all(x, "([%{}\\\\])", "\\$1")
   x
 }

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -387,14 +387,12 @@ package_url_parse <- function(x) {
     paste0("\\doi{", match, "}")
   })
 
-
   # http(s) handling
   # target: from <http:XX.XXX> to \url{http:XX.XXX}
   x <- str_replace_all(x, "<(http|https):\\/\\/(.*?)>", function(match) {
     match <- str_remove_all(match, "^<|>$")
     # Decode for docs
     match <- URLdecode(match)
-
     # Additionally, encode just the spaces (CRAN Error if not) and mask the %
     match <- str_replace_all(match, " ", "\\\\%20")
 
@@ -411,12 +409,10 @@ package_url_parse <- function(x) {
 
   x <- str_replace_all(x, patt_arxiv, function(match) {
     match <- str_remove_all(match, "^<(arXiv:|arxiv:)|>$")
-
-    # Some special cases has a format <arxiv:id [code]>. This is accepted on
-    # CRAN, see https://CRAN.R-project.org/package=ciccr
+    # Special cases has <arxiv:id [code]>.
+    # See https://CRAN.R-project.org/package=ciccr
     # Extract arxiv id, split by space
     arxiv_id <- str_split_fixed(match, " ", n = 2)[, 1]
-
 
     paste0("\\href{https://arxiv.org/abs/", arxiv_id, "}{arXiv:", match, "}")
   })

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -393,7 +393,8 @@ package_description_urls <- function(x) {
     replaced_dois <- gsub(">$", "}", replaced_dois)
 
     # Decode urls for documentation (see #1164)
-    replaced_dois <- URLdecode(replaced_dois)
+    # Use apply for compatibility with older R versions
+    replaced_dois <- unlist(lapply(replaced_dois, URLdecode))
   }
 
   # http(s) handling

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -376,37 +376,26 @@ itemize <- function(header, x) {
 }
 
 package_url_parse <- function(x) {
-
-  # DOIs handling
-  # target: from <doi:XX.XXX> to \doi{XX.XXX} to avoid CRAN Notes, etc.
+  # <doi:XX.XXX> -> \doi{XX.XXX} to avoid CRAN Notes, etc.
   x <- str_replace_all(x, "<(doi|DOI):(.*?)>", function(match) {
     match <- str_remove_all(match, "^<(doi|DOI):|>$")
-    # Decode for docs
-    match <- URLdecode(match)
-
-    paste0("\\doi{", match, "}")
+    paste0("\\doi{", URLdecode(match), "}")
   })
 
-  # http(s) handling
-  # target: from <http:XX.XXX> to \url{http:XX.XXX}
+  # <http:XX.XXX> -> \url{http:XX.XXX}
   x <- str_replace_all(x, "<(http|https):\\/\\/(.*?)>", function(match) {
     match <- str_remove_all(match, "^<|>$")
-    # Decode for docs
     match <- URLdecode(match)
     # Additionally, encode just the spaces (CRAN Error if not) and mask the %
-    match <- str_replace_all(match, " ", "\\\\%20")
+    match <- str_replace_all(match, " ", "%20")
+    match <- str_replace_all(match, "([%{}])", "\\$1")
 
     paste0("\\url{", match, "}")
   })
 
-  # ArXiv
-  # target: from <arxiv:XXX> to \href{https://arxiv.org/abs/XXX}{arXiv:XXX}
-  # This is how CRAN parses it, see: https://CRAN.R-project.org/package=alpaca
-  # See https://github.com/wch/r-source/blob/trunk/src/library/tools/R/Rd2pdf.R
-
-  # Pattern from https://github.com/wch/r-source, see previous link
+  # <arxiv:XXX> -> \href{https://arxiv.org/abs/XXX}{arXiv:XXX}
+  # https://github.com/wch/r-source/blob/trunk/src/library/tools/R/Rd2pdf.R#L149-L151
   patt_arxiv <- "<(arXiv:|arxiv:)([[:alnum:]/.-]+)([[:space:]]*\\[[^]]+\\])?>"
-
   x <- str_replace_all(x, patt_arxiv, function(match) {
     match <- str_remove_all(match, "^<(arXiv:|arxiv:)|>$")
     # Special cases has <arxiv:id [code]>.
@@ -417,5 +406,5 @@ package_url_parse <- function(x) {
     paste0("\\href{https://arxiv.org/abs/", arxiv_id, "}{arXiv:", match, "}")
   })
 
-  return(x)
+  x
 }

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -379,13 +379,13 @@ package_url_parse <- function(x) {
   # <doi:XX.XXX> -> \doi{XX.XXX} to avoid CRAN Notes, etc.
   x <- str_replace_all(x, "<(doi|DOI):(.*?)>", function(match) {
     match <- str_remove_all(match, "^<(doi|DOI):|>$")
-    paste0("\\doi{", rd_url_decode(match), "}")
+    paste0("\\doi{", escape(match), "}")
   })
 
   # <http:XX.XXX> -> \url{http:XX.XXX}
   x <- str_replace_all(x, "<(http|https):\\/\\/(.*?)>", function(match) {
     match <- str_remove_all(match, "^<|>$")
-    paste0("\\url{", rd_url_decode(match), "}")
+    paste0("\\url{", escape(match), "}")
   })
 
   # <arxiv:XXX> -> \href{https://arxiv.org/abs/XXX}{arXiv:XXX}
@@ -398,21 +398,8 @@ package_url_parse <- function(x) {
     # Extract arxiv id, split by space
     arxiv_id <- str_split_fixed(match, " ", n = 2)[, 1]
 
-    paste0("\\href{https://arxiv.org/abs/", rd_url_decode(arxiv_id), "}{arXiv:", match, "}")
+    paste0("\\href{https://arxiv.org/abs/", escape(arxiv_id), "}{arXiv:", match, "}")
   })
 
-  x
-}
-
-rd_url_decode <- function(x) {
-  # From R-exts:
-  # > Note that RFC3986-encoded URLs (e.g. using ‘%28VS.85%29’ in place of
-  # > ‘(VS.85)’) may not work correctly in versions of R before 3.1.3 and
-  # > are best avoided --- use URLdecode() to decode them.
-  x <- URLdecode(x)
-  # except for spaces
-  x <- str_replace_all(x, " ", "%20")
-  # and escape
-  x <- str_replace_all(x, "([%{}\\\\])", "\\$1")
   x
 }

--- a/tests/testthat/_snaps/object-package.md
+++ b/tests/testthat/_snaps/object-package.md
@@ -24,3 +24,24 @@
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID}) (extra)"
 
+# can autolink urls on package Description
+
+    Code
+      parsed
+    Output
+      [1] "\\url{https://github.com/} Secured \\url{https://github.com/}. No link <www.github.com/>."
+
+# can autolink dois on package Description
+
+    Code
+      parsed
+    Output
+      [1] "\\doi{10.000/ret.234} With ampersands \\doi{aaa&.bbb.&c12}. No link <doi.baddoi>."
+
+# can autolink arxiv on package Description
+
+    Code
+      parsed
+    Output
+      [1] "\\href{https://arxiv.org/abs/somecode}{arxiv:somecode} With upper \\href{https://arxiv.org/abs/somecode}{arxiv:somecode}."
+

--- a/tests/testthat/_snaps/object-package.md
+++ b/tests/testthat/_snaps/object-package.md
@@ -36,12 +36,12 @@
     Code
       parsed
     Output
-      [1] "\\doi{10.000/ret.234} With ampersands \\doi{aaa&.bbb.&c12}. No link <doi.baddoi>."
+      [1] "\\doi{10.000/ret.234} With ampersands \\doi{aaa&.bbb.&c12}. No link <doi.baddoi>. I can use encoded dois \\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
 
 # can autolink arxiv on package Description
 
     Code
       parsed
     Output
-      [1] "\\href{https://arxiv.org/abs/somecode}{arxiv:somecode} With upper \\href{https://arxiv.org/abs/somecode}{arxiv:somecode}."
+      [1] "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode} With upper \\href{https://arxiv.org/abs/somecode}{arXiv:somecode}."
 

--- a/tests/testthat/_snaps/object-package.md
+++ b/tests/testthat/_snaps/object-package.md
@@ -24,12 +24,19 @@
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID}) (extra)"
 
+# package description not affected if no links
+
+    Code
+      parsed
+    Output
+      [1] "A simple description with no links."
+
 # can autolink urls on package Description
 
     Code
       parsed
     Output
-      [1] "\\url{https://github.com/} Secured \\url{https://github.com/}. No link <www.github.com/>."
+      [1] "\\url{https://github.com/} Secured \\url{https://github.com/}. No link <www.github.com/>. url masked with spaces \\url{https://database.ich.org/sites/default/files/Q1E\\%20Guideline.pdf} url fully masked \\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
 
 # can autolink dois on package Description
 
@@ -43,5 +50,5 @@
     Code
       parsed
     Output
-      [1] "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode} With upper \\href{https://arxiv.org/abs/somecode}{arXiv:somecode}."
+      [1] "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode} With upper \\href{https://arxiv.org/abs/somecode2}{arXiv:somecode2}. Strange arxiv \\href{https://arxiv.org/abs/2004.08318}{arXiv:2004.08318 [econ.EM]} Old-style arxiv \\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
 

--- a/tests/testthat/_snaps/object-package.md
+++ b/tests/testthat/_snaps/object-package.md
@@ -24,31 +24,3 @@
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID}) (extra)"
 
-# package description not affected if no links
-
-    Code
-      parsed
-    Output
-      [1] "A simple description with no links."
-
-# can autolink urls on package Description
-
-    Code
-      parsed
-    Output
-      [1] "\\url{https://github.com/} Secured \\url{https://github.com/}. No link <www.github.com/>. url masked with spaces \\url{https://database.ich.org/sites/default/files/Q1E\\%20Guideline.pdf} url fully masked \\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
-
-# can autolink dois on package Description
-
-    Code
-      parsed
-    Output
-      [1] "\\doi{10.000/ret.234} With ampersands \\doi{aaa&.bbb.&c12}. No link <doi.baddoi>. I can use encoded dois \\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
-
-# can autolink arxiv on package Description
-
-    Code
-      parsed
-    Output
-      [1] "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode} With upper \\href{https://arxiv.org/abs/somecode2}{arXiv:somecode2}. Strange arxiv \\href{https://arxiv.org/abs/2004.08318}{arXiv:2004.08318 [econ.EM]} Old-style arxiv \\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
-

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -26,16 +26,43 @@ test_that("can convert DOIs in url", {
   )
 })
 
-test_that("package description not affected if no links", {
-  
+test_that("can autolink urls on package Description", {
   expect_equal(
-    package_url_parse("Simple description with no links."),
-    "Simple description with no links."
+    package_url_parse("x <https://x.com> y"),
+    "x \\url{https://x.com} y"
+  )
+  expect_equal(
+    package_url_parse("x <https://x.com/%3C-%3E> y"),
+    "x \\url{https://x.com/<->} y"
+  )
+  expect_equal(
+    package_url_parse("x <https://x.com/%20> y"),
+    "x \\url{https://x.com/\\%20} y"
   )
 })
 
-test_that("Autolink several matching patterns", {
+test_that("can autolink DOIs", {
+  expect_equal(package_url_parse("x <doi:abcdef> y"), "x \\doi{abcdef} y")
+  expect_equal(package_url_parse("x <DOI:abcdef> y"), "x \\doi{abcdef} y")
+  expect_equal(package_url_parse("x <DOI:%3C-%3E> y"), "x \\doi{<->} y")
+})
 
+test_that("can autolink arxiv", {
+  expect_equal(
+    package_url_parse("x <arXiv:abc> y"),
+    "x \\href{https://arxiv.org/abs/abc}{arXiv:abc} y"
+  )
+  expect_equal(
+    package_url_parse("x <arxiv:abc> y"),
+    "x \\href{https://arxiv.org/abs/abc}{arXiv:abc} y"
+  )
+  expect_equal(
+    package_url_parse("x <arxiv:abc [def]> y"),
+    "x \\href{https://arxiv.org/abs/abc}{arXiv:abc [def]} y"
+  )
+})
+
+test_that("autolink several matching patterns", {
   text <- "url <http://a.com> doi <doi:xx> arxiv <arXiv:xx>"
   expect_equal(
     package_url_parse(text),
@@ -45,101 +72,4 @@ test_that("Autolink several matching patterns", {
       "arxiv \\href{https://arxiv.org/abs/xx}{arXiv:xx}"
     )
   )
-})
-
-test_that("can autolink urls on package Description", {
-
-  # http and https
-  expect_equal(
-    package_url_parse(
-      "<http://service.iris.edu/> and <https://abj.org.br/>"
-    ),
-    "\\url{http://service.iris.edu/} and \\url{https://abj.org.br/}"
-  )
-
-  # Decode URL
-  expect_equal(
-    package_url_parse(
-      "<https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ%3AL%3A2015%3A012%3ATOC>"
-    ),
-    "\\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
-  )
-
-  # Decode URL with spaces
-  expect_equal(
-    package_url_parse(
-      "<https://www.sibm.it/SITO%20MEDITS/principaleprogramme.htm>>"
-    ),
-    "\\url{https://www.sibm.it/SITO\\%20MEDITS/principaleprogramme.htm}>"
-  )
-})
-
-test_that("can autolink dois on package Description", {
-
-  # Regular DOI
-  expect_equal(
-    package_url_parse(
-      "A DOI: <doi:10.1093/biomet/asu017>"
-    ),
-    "A DOI: \\doi{10.1093/biomet/asu017}"
-  )
-
-  # With upcase
-  expect_equal(
-    package_url_parse(
-      "Another DOI: <DOI:10.1086/160554>"
-    ),
-    "Another DOI: \\doi{10.1086/160554}"
-  )
-  # An encoded DOI
-  expect_equal(
-    package_url_parse(
-      "Encoded doi: <doi:10.1175/1520-0469(1981)038%3C1179:TSLROA%3E2.0.CO;2>"
-    ),
-    "Encoded doi: \\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
-  )
-})
-
-
-test_that("can autolink arxiv on package Description", {
-
-  # Regular arXiv
-  expect_equal(
-    package_url_parse(
-      "'abess' <arXiv:1702.04690>"
-    ),
-    "'abess' \\href{https://arxiv.org/abs/1702.04690}{arXiv:1702.04690}"
-  )
-
-  # Different casing: arxiv:
-  expect_equal(
-    package_url_parse("'DLL' <arxiv:1907.12732>"),
-    "'DLL' \\href{https://arxiv.org/abs/1907.12732}{arXiv:1907.12732}"
-  )
-
-  # Another valid format
-  expect_equal(
-    package_url_parse("<arXiv:1602.03990v2 [stat.ME]>"),
-    "\\href{https://arxiv.org/abs/1602.03990v2}{arXiv:1602.03990v2 [stat.ME]}"
-  )
-
-  # Old-style format
-  expect_equal(
-    package_url_parse("<arXiv:quant-ph/0208069>"),
-    "\\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
-  )
-})
-
-test_that("No autolinking if wrong pattern", {
-  badurl <- "<www.a.org> and <http:r.com"
-  expect_equal(package_url_parse(badurl), badurl)
-
-  ftpurl <- "<ftp://cran.r-project.org/incoming/>"
-  expect_equal(package_url_parse(ftpurl), ftpurl)
-
-  baddoi <- "<doi.109/10sm> and <dOi:10.20290>"
-  expect_equal(package_url_parse(baddoi), baddoi)
-
-  badarxiv <- "<ARXIV:1907.12732>"
-  expect_equal(package_url_parse(badarxiv), badarxiv)
 })

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -27,15 +27,15 @@ test_that("can convert DOIs in url", {
 })
 
 test_that("package description not affected if no links", {
-  text <- "A simple description with no links."
-
+  
   expect_equal(
-    package_url_parse(text),
-    text
+    package_url_parse("Simple description with no links."),
+    "Simple description with no links."
   )
 })
 
 test_that("Autolink several matching patterns", {
+
   text <- "url <http://a.com> doi <doi:xx> arxiv <arXiv:xx>"
   expect_equal(
     package_url_parse(text),

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -33,18 +33,14 @@ test_that("can autolink urls on package Description", {
   )
   expect_equal(
     package_url_parse("x <https://x.com/%3C-%3E> y"),
-    "x \\url{https://x.com/<->} y"
-  )
-  expect_equal(
-    package_url_parse("x <https://x.com/%20> y"),
-    "x \\url{https://x.com/\\%20} y"
+    "x \\url{https://x.com/\\%3C-\\%3E} y"
   )
 })
 
 test_that("can autolink DOIs", {
   expect_equal(package_url_parse("x <doi:abcdef> y"), "x \\doi{abcdef} y")
   expect_equal(package_url_parse("x <DOI:abcdef> y"), "x \\doi{abcdef} y")
-  expect_equal(package_url_parse("x <DOI:%3C-%3E> y"), "x \\doi{<->} y")
+  expect_equal(package_url_parse("x <DOI:%3C-%3E> y"), "x \\doi{\\%3C-\\%3E} y")
 })
 
 test_that("can autolink arxiv", {

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -17,3 +17,63 @@ test_that("person turned into meaningful text", {
     person_desc(comment = c("ORCID" = "1234", "extra"))
   })
 })
+
+
+test_that("can autolink urls on package Description", {
+  urls <- paste(
+    "<https://github.com/>",
+    "Secured <https://github.com/>.",
+    "No link <www.github.com/>."
+  )
+
+  parsed <- package_description_urls(urls)
+
+  expect_equal(
+    parsed,
+    paste(
+      "\\url{https://github.com/}",
+      "Secured \\url{https://github.com/}.",
+      "No link <www.github.com/>."
+    )
+  )
+  expect_snapshot(parsed)
+})
+
+test_that("can autolink dois on package Description", {
+  doi <- paste(
+    "<doi:10.000/ret.234>",
+    "With ampersands <DOI:aaa&.bbb.&c12>.",
+    "No link <doi.baddoi>."
+  )
+
+  parsed <- package_description_urls(doi)
+
+  expect_equal(
+    parsed,
+    paste(
+      "\\doi{10.000/ret.234}",
+      "With ampersands \\doi{aaa&.bbb.&c12}.",
+      "No link <doi.baddoi>."
+    )
+  )
+  expect_snapshot(parsed)
+})
+
+
+test_that("can autolink arxiv on package Description", {
+  arxiv <- paste(
+    "<arxiv:somecode>",
+    "With upper <arXiv:somecode>."
+  )
+
+  parsed <- package_description_urls(arxiv)
+
+  expect_equal(
+    parsed,
+    paste(
+      "\\href{https://arxiv.org/abs/somecode}{arxiv:somecode}",
+      "With upper \\href{https://arxiv.org/abs/somecode}{arxiv:somecode}."
+    )
+  )
+  expect_snapshot(parsed)
+})

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -18,11 +18,27 @@ test_that("person turned into meaningful text", {
   })
 })
 
+test_that("package description not affected if no links", {
+  text <- "A simple description with no links."
+
+  parsed <- package_description_urls(text)
+
+  expect_equal(
+    parsed,
+    text
+  )
+  expect_snapshot(parsed)
+})
+
 test_that("can autolink urls on package Description", {
   urls <- paste(
     "<https://github.com/>",
     "Secured <https://github.com/>.",
-    "No link <www.github.com/>."
+    "No link <www.github.com/>.",
+    "url masked with spaces",
+    "<https://database.ich.org/sites/default/files/Q1E%20Guideline.pdf>",
+    "url fully masked",
+    "<https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ%3AL%3A2015%3A012%3ATOC>"
   )
 
   parsed <- package_description_urls(urls)
@@ -32,7 +48,11 @@ test_that("can autolink urls on package Description", {
     paste(
       "\\url{https://github.com/}",
       "Secured \\url{https://github.com/}.",
-      "No link <www.github.com/>."
+      "No link <www.github.com/>.",
+      "url masked with spaces",
+      "\\url{https://database.ich.org/sites/default/files/Q1E\\%20Guideline.pdf}",
+      "url fully masked",
+      "\\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
     )
   )
   expect_snapshot(parsed)
@@ -66,7 +86,11 @@ test_that("can autolink dois on package Description", {
 test_that("can autolink arxiv on package Description", {
   arxiv <- paste(
     "<arxiv:somecode>",
-    "With upper <arXiv:somecode>."
+    "With upper <arXiv:somecode2>.",
+    "Strange arxiv",
+    "<arXiv:2004.08318 [econ.EM]>",
+    "Old-style arxiv",
+    "<arXiv:quant-ph/0208069>"
   )
 
   parsed <- package_description_urls(arxiv)
@@ -75,7 +99,11 @@ test_that("can autolink arxiv on package Description", {
     parsed,
     paste(
       "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode}",
-      "With upper \\href{https://arxiv.org/abs/somecode}{arXiv:somecode}."
+      "With upper \\href{https://arxiv.org/abs/somecode2}{arXiv:somecode2}.",
+      "Strange arxiv",
+      "\\href{https://arxiv.org/abs/2004.08318}{arXiv:2004.08318 [econ.EM]}",
+      "Old-style arxiv",
+      "\\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
     )
   )
   expect_snapshot(parsed)

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -29,90 +29,117 @@ test_that("can convert DOIs in url", {
 test_that("package description not affected if no links", {
   text <- "A simple description with no links."
 
-  parsed <- package_description_urls(text)
-
   expect_equal(
-    parsed,
+    package_url_parse(text),
     text
   )
-  expect_snapshot(parsed)
+})
+
+test_that("Autolink several matching patterns", {
+  text <- "url <http://a.com> doi <doi:xx> arxiv <arXiv:xx>"
+  expect_equal(
+    package_url_parse(text),
+    paste(
+      "url \\url{http://a.com}",
+      "doi \\doi{xx}",
+      "arxiv \\href{https://arxiv.org/abs/xx}{arXiv:xx}"
+    )
+  )
 })
 
 test_that("can autolink urls on package Description", {
-  urls <- paste(
-    "<https://github.com/>",
-    "Secured <https://github.com/>.",
-    "No link <www.github.com/>.",
-    "url masked with spaces",
-    "<https://database.ich.org/sites/default/files/Q1E%20Guideline.pdf>",
-    "url fully masked",
-    "<https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ%3AL%3A2015%3A012%3ATOC>"
-  )
 
-  parsed <- package_description_urls(urls)
-
+  # http and https
   expect_equal(
-    parsed,
-    paste(
-      "\\url{https://github.com/}",
-      "Secured \\url{https://github.com/}.",
-      "No link <www.github.com/>.",
-      "url masked with spaces",
-      "\\url{https://database.ich.org/sites/default/files/Q1E\\%20Guideline.pdf}",
-      "url fully masked",
-      "\\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
-    )
+    package_url_parse(
+      "<http://service.iris.edu/> and <https://abj.org.br/>"
+    ),
+    "\\url{http://service.iris.edu/} and \\url{https://abj.org.br/}"
   )
-  expect_snapshot(parsed)
+
+  # Decode URL
+  expect_equal(
+    package_url_parse(
+      "<https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ%3AL%3A2015%3A012%3ATOC>"
+    ),
+    "\\url{https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:012:TOC}"
+  )
+
+  # Decode URL with spaces
+  expect_equal(
+    package_url_parse(
+      "<https://www.sibm.it/SITO%20MEDITS/principaleprogramme.htm>>"
+    ),
+    "\\url{https://www.sibm.it/SITO\\%20MEDITS/principaleprogramme.htm}>"
+  )
 })
 
 test_that("can autolink dois on package Description", {
-  doi <- paste(
-    "<doi:10.000/ret.234>",
-    "With ampersands <DOI:aaa&.bbb.&c12>.",
-    "No link <doi.baddoi>.",
-    "I can use encoded dois",
-    "<doi:10.1175/1520-0469(1981)038%3C1179:TSLROA%3E2.0.CO;2>"
-  )
 
-  parsed <- package_description_urls(doi)
-
+  # Regular DOI
   expect_equal(
-    parsed,
-    paste(
-      "\\doi{10.000/ret.234}",
-      "With ampersands \\doi{aaa&.bbb.&c12}.",
-      "No link <doi.baddoi>.",
-      "I can use encoded dois",
-      "\\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
-    )
+    package_url_parse(
+      "A DOI: <doi:10.1093/biomet/asu017>"
+    ),
+    "A DOI: \\doi{10.1093/biomet/asu017}"
   )
-  expect_snapshot(parsed)
+
+  # With upcase
+  expect_equal(
+    package_url_parse(
+      "Another DOI: <DOI:10.1086/160554>"
+    ),
+    "Another DOI: \\doi{10.1086/160554}"
+  )
+  # An encoded DOI
+  expect_equal(
+    package_url_parse(
+      "Encoded doi: <doi:10.1175/1520-0469(1981)038%3C1179:TSLROA%3E2.0.CO;2>"
+    ),
+    "Encoded doi: \\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
+  )
 })
 
 
 test_that("can autolink arxiv on package Description", {
-  arxiv <- paste(
-    "<arxiv:somecode>",
-    "With upper <arXiv:somecode2>.",
-    "Strange arxiv",
-    "<arXiv:2004.08318 [econ.EM]>",
-    "Old-style arxiv",
-    "<arXiv:quant-ph/0208069>"
-  )
 
-  parsed <- package_description_urls(arxiv)
-
+  # Regular arXiv
   expect_equal(
-    parsed,
-    paste(
-      "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode}",
-      "With upper \\href{https://arxiv.org/abs/somecode2}{arXiv:somecode2}.",
-      "Strange arxiv",
-      "\\href{https://arxiv.org/abs/2004.08318}{arXiv:2004.08318 [econ.EM]}",
-      "Old-style arxiv",
-      "\\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
-    )
+    package_url_parse(
+      "'abess' <arXiv:1702.04690>"
+    ),
+    "'abess' \\href{https://arxiv.org/abs/1702.04690}{arXiv:1702.04690}"
   )
-  expect_snapshot(parsed)
+
+  # Different casing: arxiv:
+  expect_equal(
+    package_url_parse("'DLL' <arxiv:1907.12732>"),
+    "'DLL' \\href{https://arxiv.org/abs/1907.12732}{arXiv:1907.12732}"
+  )
+
+  # Another valid format
+  expect_equal(
+    package_url_parse("<arXiv:1602.03990v2 [stat.ME]>"),
+    "\\href{https://arxiv.org/abs/1602.03990v2}{arXiv:1602.03990v2 [stat.ME]}"
+  )
+
+  # Old-style format
+  expect_equal(
+    package_url_parse("<arXiv:quant-ph/0208069>"),
+    "\\href{https://arxiv.org/abs/quant-ph/0208069}{arXiv:quant-ph/0208069}"
+  )
+})
+
+test_that("No autolinking if wrong pattern", {
+  badurl <- "<www.a.org> and <http:r.com"
+  expect_equal(package_url_parse(badurl), badurl)
+
+  ftpurl <- "<ftp://cran.r-project.org/incoming/>"
+  expect_equal(package_url_parse(ftpurl), ftpurl)
+
+  baddoi <- "<doi.109/10sm> and <dOi:10.20290>"
+  expect_equal(package_url_parse(baddoi), baddoi)
+
+  badarxiv <- "<ARXIV:1907.12732>"
+  expect_equal(package_url_parse(badarxiv), badarxiv)
 })

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -18,7 +18,6 @@ test_that("person turned into meaningful text", {
   })
 })
 
-
 test_that("can autolink urls on package Description", {
   urls <- paste(
     "<https://github.com/>",
@@ -43,7 +42,9 @@ test_that("can autolink dois on package Description", {
   doi <- paste(
     "<doi:10.000/ret.234>",
     "With ampersands <DOI:aaa&.bbb.&c12>.",
-    "No link <doi.baddoi>."
+    "No link <doi.baddoi>.",
+    "I can use encoded dois",
+    "<doi:10.1175/1520-0469(1981)038%3C1179:TSLROA%3E2.0.CO;2>"
   )
 
   parsed <- package_description_urls(doi)
@@ -53,7 +54,9 @@ test_that("can autolink dois on package Description", {
     paste(
       "\\doi{10.000/ret.234}",
       "With ampersands \\doi{aaa&.bbb.&c12}.",
-      "No link <doi.baddoi>."
+      "No link <doi.baddoi>.",
+      "I can use encoded dois",
+      "\\doi{10.1175/1520-0469(1981)038<1179:TSLROA>2.0.CO;2}"
     )
   )
   expect_snapshot(parsed)
@@ -71,8 +74,8 @@ test_that("can autolink arxiv on package Description", {
   expect_equal(
     parsed,
     paste(
-      "\\href{https://arxiv.org/abs/somecode}{arxiv:somecode}",
-      "With upper \\href{https://arxiv.org/abs/somecode}{arxiv:somecode}."
+      "\\href{https://arxiv.org/abs/somecode}{arXiv:somecode}",
+      "With upper \\href{https://arxiv.org/abs/somecode}{arXiv:somecode}."
     )
   )
   expect_snapshot(parsed)


### PR DESCRIPTION
Hi, this PR close #1265, close #1164 .

I considered here three different conversions:
- From `<doi:...>` to `\doi{...}` to avoid CRAN Notes
- From `<http://abc.com>` to `\url{http://abc.com}`
- From `<arXiv:id>` to `\href{https://arxiv.org/abs/id}{arXiv:id}`, following how CRAN renders it ([Example](https://cran.r-project.org/web/packages/alpaca/index.html)).

I also considered  the encoding of urls and DOIs, that I decided to unencode on the man page (except whitespaces on url, that throws an error).

On top of the tests, I created a mock package for testing purposes, and I had no problems at all.  The urls, dois and arXiv are taken for real CRAN packages. See the testing Description:

```
...
Description: This os a full text to check the implementation of
    autolinking urls by roxygen2. The examples are taken from CRAN
    packages. Example on urls: See a non secured link on 'IRISSeismic',
    <http://service.iris.edu/>, regular link on 'abjutils'
    <https://abj.org.br/>, a link with masks on 'MEDITS'
    <https://www.sibm.it/SITO%20MEDITS/principaleprogramme.htm> and the
    last with different masks from 'ggsolvencyii'
    <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ%3AL%3A2015%3A012%3ATOC>.
    Let's talk about dois: a regular doi from 'abclass'
    <doi:10.1093/biomet/asu017>, with caps from 'zeitgebr'
    <DOI:10.1086/160554> and with masks from 'raytracing'
    <doi:10.1175/1520-0469(1996)053%3C2365:PORWON%3E2.0.CO;2>.  By last,
    arXiv: One from 'abess' <arXiv:1702.04690>, different casing by 'DLL'
    <arxiv:1907.12732>, strange on from 'grove' <arXiv:1602.03990v2
    [stat.ME]> and old-style from 'QGameTheory' <arXiv:quant-ph/0208069>.
...
```

The package passes `devtools::check(cran =TRUE, remote = TRUE)`. See the final parsed result: 
https://github.com/dieghernan/testroxy/blob/main/man/testroxy-package.Rd

I also checked that it plays nice with **pkgdown**:

https://dieghernan.github.io/testroxy/reference/testroxy-package.html

Regards


