### PR TITLE
Fix CRAN Warning when non-breaking space in default function argument value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,9 @@
   DOIs in the `URL` field of the `DESCRIPTION` are now converted to Rd's 
   special `\doi{}` tag (@ThierryO, #1296).
 
+* Non-breaking spaces in default argument values are preserved in
+  Rd's usage (#1342, @zeehio).
+
 # roxygen2 7.1.2
 
 * The new `@examplesIf` tag can be used to create conditional

--- a/R/rd-usage.R
+++ b/R/rd-usage.R
@@ -154,5 +154,5 @@ wrap_usage <- function(name, format_name, formals, suffix = NULL, width = 80L) {
 # used for testing
 call_to_usage <- function(code, env = pkg_env()) {
   obj <- call_to_object(!!enexpr(code), env)
-  gsub("\u{A0}", " ", as.character(object_usage(obj)))
+  as.character(object_usage(obj))
 }

--- a/R/rd-usage.R
+++ b/R/rd-usage.R
@@ -133,16 +133,18 @@ wrap_usage <- function(name, format_name, formals, suffix = NULL, width = 80L) {
   bare <- args_call(name, args)
   if (!str_detect(bare, "\n") && nchar(bare, type = "width") < width) {
     out <- args_call(format_name(name), args)
+    out <- gsub("\u{A0}", " ", out, useBytes = TRUE)
   } else if (roxy_meta_get("old_usage", FALSE)) {
     x <- args_call(format_name(name), args)
     out <- wrapUsage(x, width = as.integer(width), indent = 2)
+    out <- gsub("\u{A0}", " ", out, useBytes = TRUE)
   } else {
     args <- paste0("  ", args)
     args <- map_chr(args, wrapUsage, width = 90, indent = 4)
+    args <- map_chr(args, ~sub("\u{A0}=\u{A0}", " = ", ., fixed = TRUE))
     out <- paste0(format_name(name), "(\n", paste0(args, collapse = ",\n"), "\n)")
   }
 
-  out <- gsub("\u{A0}", " ", out, useBytes = TRUE)
   Encoding(out) <- "UTF-8"
 
   rd(paste0(out, suffix))

--- a/R/rd-usage.R
+++ b/R/rd-usage.R
@@ -111,8 +111,8 @@ usage_args <- function(args) {
   map_chr(args, arg_to_text)
 }
 
-args_string <- function(x) {
-  sep <- ifelse(x != "", "\u{A0}=\u{A0}", "")
+args_string <- function(x, space = "\u{A0}") {
+  sep <- ifelse(x != "", paste0(space, "=", space), "")
   arg_names <- escape(auto_backtick(names(x)))
   paste0(arg_names, sep, escape(x))
 }
@@ -132,8 +132,7 @@ wrap_usage <- function(name, format_name, formals, suffix = NULL, width = 80L) {
   # Do we need any wrapping?
   bare <- args_call(name, args)
   if (!str_detect(bare, "\n") && nchar(bare, type = "width") < width) {
-    out <- args_call(format_name(name), args)
-    out <- gsub("\u{A0}", " ", out, useBytes = TRUE)
+    out <- args_call(format_name(name), args_string(usage_args(formals), space = " "))
   } else if (roxy_meta_get("old_usage", FALSE)) {
     x <- args_call(format_name(name), args)
     out <- wrapUsage(x, width = as.integer(width), indent = 2)

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -104,6 +104,30 @@ test_that("usage captured from formals", {
   )
 })
 
+
+test_that("usage preserves non-breaking-space", {
+  expect_equal(
+    call_to_usage(f <- function(a = "x\u{A0}=\u{A0}1") {}),
+    "f(a = \"x\u{A0}=\u{A0}1\")"
+  )
+  expect_equal(
+    call_to_usage(f <- function(
+    a = "x\u{A0}=\u{A0}1",
+    b = "looooooooooooooooooooooooooooooooooooooong",
+    c = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarg") {}
+    ),
+    paste(
+      "f(",
+      "  a = \"x\u{A0}=\u{A0}1\",",
+      "  b = \"looooooooooooooooooooooooooooooooooooooong\",",
+      "  c = \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarg\"",
+      ")",
+      sep = "\n"
+    )
+  )
+})
+
+
 test_that("argument containing function is generates correct usage", {
   expect_equal(
     call_to_usage(f <- function(a = function(x) 1) {}),


### PR DESCRIPTION
- Closes #1342 

I don't have all the context of why there are non-breaking spaces introduced and afterwards replaced. Probably it was a Windows encoding issue already addressed on R-4.2, with its UTF-8 improvements.

The change in this pull request is as follows:

Before:
- The usage Rd section uses a structure like: `"<argument_name><space>=<space><default_value>"` for each argument
- When `default_value` contains `"\u{A0}"` (a non-breaking space character), the generated usage replaces that character with a regular space, leading to a CRAN warning due to the mismatch. (This is a bug, in my opinon)

After:
- The usage Rd section uses a structure like: `"<argument_name><space>=<space><default_value>"`
- When `default_value` contains `"\u{A0}"` (a non-breaking space character), the generated usage preserves that character.

In the future, when R4.2 is required and assuming non-breaking spaces are well supported in R-4.2 Rd files, roxygen2 could use non-breaking spaces to wrap the `=` sign that separates the argument name from its default value. This is out of the scope of this pull request.

