### PR TITLE
Edits to rd-formatting.Rmd and roxygen2.Rmd

### DIFF
--- a/vignettes/rd-formatting.Rmd
+++ b/vignettes/rd-formatting.Rmd
@@ -147,7 +147,7 @@ Regular Markdown lists are recognized and converted to `\enumerate{}` or `\itemi
 #' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means
 #'   red. Transparency (alpha channel) values are ignored.
 #' * A one-column matrix with three rows for the red, green
-#'   and blue channels, as returned by [grDevices::col2rgb()]
+#'   and blue channels, as returned by [grDevices::col2rgb()].
 ```
 
 Nested lists are also supported.

--- a/vignettes/rd-formatting.Rmd
+++ b/vignettes/rd-formatting.Rmd
@@ -146,7 +146,7 @@ Regular Markdown lists are recognized and converted to `\enumerate{}` or `\itemi
 #' * An R color name, see `colors()`.
 #' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means
 #'   red. Transparency (alpha channel) values are ignored.
-#' * A one-column matrix with three rows for the red, green
+#' * A one-column matrix with three rows for the red, green,
 #'   and blue channels, as returned by [grDevices::col2rgb()].
 ```
 

--- a/vignettes/rd-formatting.Rmd
+++ b/vignettes/rd-formatting.Rmd
@@ -40,8 +40,8 @@ Here is an example roxygen chunk that uses Markdown.
 #' the roxygen2 package. See the documentation and vignettes of
 #' that package to learn how to use roxygen.
 #'
-#' @param pkg package description, can be path or package name.  See
-#'   [as.package()] for more information
+#' @param pkg Package description, can be path or package name.  See
+#'   [as.package()] for more information.
 #' @param clean,reload Deprecated.
 #' @inheritParams roxygen2::roxygenise
 #' @seealso [roxygen2::roxygenize()], `browseVignettes("roxygen2")`

--- a/vignettes/roxygen2.Rmd
+++ b/vignettes/roxygen2.Rmd
@@ -11,7 +11,7 @@ vignette: >
 knitr::opts_chunk$set(comment = "#>", collapse = TRUE)
 ```
 
-Documentation is one of the most important aspects of good code. Without it, users won't know how to use your package, and are unlikely to do so. Documentation is also useful for you in the future (so you remember what the heck you were thinking!), and for other developers working on your package. The goal of roxygen2 is to make documenting your code as easy as possible. R provides a standard way of documenting packages: you write `.Rd` files in the `man/` directory. These files use a custom syntax, loosely based on LaTeX Roxygen2 provides a number of advantages over writing `.Rd` files by hand:
+Documentation is one of the most important aspects of good code. Without it, users won't know how to use your package, and are unlikely to do so. Documentation is also useful for you in the future (so you remember what the heck you were thinking!), and for other developers working on your package. The goal of roxygen2 is to make documenting your code as easy as possible. R provides a standard way of documenting packages: you write `.Rd` files in the `man/` directory. These files use a custom syntax, loosely based on LaTeX. Roxygen2 provides a number of advantages over writing `.Rd` files by hand:
 
 * Code and documentation are adjacent so when you modify your code, it's easy
   to remember that you need to update the documentation.

--- a/vignettes/roxygen2.Rmd
+++ b/vignettes/roxygen2.Rmd
@@ -30,7 +30,7 @@ This vignette provides a high-level description of roxygen2 and how the three ma
   describe how to generate function documentation via `.Rd` files.
 
 * [Managing your `NAMESPACE`](namespace.html) describes how to generate
-  a `NAMESPACE` file, how namespacing works in R, and how you can use Roxygen2 to be
+  a `NAMESPACE` file, how namespacing works in R, and how you can use roxygen2 to be
   specific about what your package needs and supplies.
 
 * See [update_collate()] for the details of `@include`, which for complicated

--- a/vignettes/roxygen2.Rmd
+++ b/vignettes/roxygen2.Rmd
@@ -61,9 +61,9 @@ The process starts when you add specially formatted roxygen comments to your sou
 ```{r}
 #' Add together two numbers
 #'
-#' @param x A number
-#' @param y A number
-#' @return The sum of \code{x} and \code{y}
+#' @param x A number.
+#' @param y A number.
+#' @return The sum of \code{x} and \code{y}.
 #' @examples
 #' add(1, 1)
 #' add(10, 1)
@@ -83,12 +83,12 @@ For the example above, this will generate `man/add.Rd` that looks like:
 add(x, y)
 }
 \arguments{
-  \item{x}{A number}
+  \item{x}{A number.}
 
-  \item{y}{A number}
+  \item{y}{A number.}
 }
 \value{
-The sum of \code{x} and \code{y}
+The sum of \code{x} and \code{y}.
 }
 \description{
 Add together two numbers
@@ -116,8 +116,8 @@ For example, dplyr has `between.cpp` which starts:
 //' efficiently in C++ for local values, and translated to the
 //' appropriate SQL for remote tables.
 //'
-//' @param x A numeric vector of values
-//' @param left,right Boundary values
+//' @param x A numeric vector of values.
+//' @param left,right Boundary values.
 //' @export
 //' @examples
 //' between(1:12, 7, 9)
@@ -138,8 +138,8 @@ This is automatically translated to the following R code in `RcppExports.R`:
 #' efficiently in C++ for local values, and translated to the
 #' appropriate SQL for remote tables.
 #'
-#' @param x A numeric vector of values
-#' @param left,right Boundary values
+#' @param x A numeric vector of values.
+#' @param left,right Boundary values.
 #' @export
 #' @examples
 #' between(1:12, 7, 9)

--- a/vignettes/roxygen2.Rmd
+++ b/vignettes/roxygen2.Rmd
@@ -33,7 +33,7 @@ This vignette provides a high-level description of roxygen2 and how the three ma
   a `NAMESPACE` file, how namespacing works in R, and how you can use roxygen2 to be
   specific about what your package needs and supplies.
 
-* See [update_collate()] for the details of `@include`, which for complicated
+* See `update_collate()` for the details of `@include`, which for complicated
   reasons is not implemented as a roclet.
 
 ## Running roxygen


### PR DESCRIPTION
Adds full stops to sentences in @param tags to match the style guide to close #1360 as well as a few other very minor edits that I found while reading the vignettes.

I do have a question though, how come the following
https://github.com/r-lib/roxygen2/blob/f3f30a607befcfdd08bbb716677fb28493ed5879/vignettes/roxygen2.Rmd#L45
doesn't provide a link in the [html (packagedown) version of the vignette](https://roxygen2.r-lib.org/articles/roxygen2.html)?