### PR TITLE
Only use nbsp for old style usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # roxygen2 (development version)
 
+* Automated usage no longer mangles nbsp in default arguments (#1342).
+
 * Give useful error if `@describeIn` can't combine docs (#1366).
 
 * Code evaluated in inline markdown code chunks and `@eval`/`@evalRd`/

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -354,4 +354,9 @@ test_that("old wrapping style doesn't change unexpectedly", {
   })
 })
 
-
+test_that("preserves non-breaking-space", {
+   expect_equal(
+     call_to_usage(f <- function(a = "\u{A0}") {}),
+     'f(a = "\u{A0}")'
+   )
+})


### PR DESCRIPTION
Fixes #1342. Closes #1343.

@zeehio I took a slightly different approach because the nbsp are only needed for the old style usage wrapping.