### PR TITLE
Allow overriding default knitr chunk options

### DIFF
--- a/R/markdown.R
+++ b/R/markdown.R
@@ -110,7 +110,13 @@ eval_code_node <- function(node, env) {
     # write knitr markup for fenced code
     text <- paste0("```", xml_attr(node, "info"), "\n", xml_text(node), "```\n")
   }
-  roxy_knit(text, env, knitr_chunk_defaults)
+
+  chunk_opts <- modifyList(
+    knitr_chunk_defaults,
+    roxy_meta_get("knitr_chunk_options", NULL)
+  )
+
+  roxy_knit(text, env, chunk_opts)
 }
 
 knitr_chunk_defaults <- list(

--- a/R/options.R
+++ b/R/options.R
@@ -28,6 +28,8 @@
 #' * `rd_family_title` `<list>`: overrides for `@family` titles. See the
 #'    _rd_ vignette for details: `vignette("rd", package = "roxygen2")`
 #'
+#' * `knitr_chunk_options`: default chunk options used for knitr.
+#'
 #' @section How to set:
 #' Either set in `DESCRIPTION`:
 #'
@@ -60,7 +62,8 @@ load_options <- function(base_path = ".") {
     markdown = FALSE,
     r6 = TRUE,
     current_package = NA_character_,
-    rd_family_title = list()
+    rd_family_title = list(),
+    knitr_chunk_options = NULL
   )
 
   unknown_opts <- setdiff(names(opts), names(defaults))

--- a/man/load_options.Rd
+++ b/man/load_options.Rd
@@ -33,6 +33,7 @@ Options in \code{man/roxygen/meta.R} override those present in \code{DESCRIPTION
 \item \code{current_package} \verb{<string>} (read only): name of package being documented.
 \item \code{rd_family_title} \verb{<list>}: overrides for \verb{@family} titles. See the
 \emph{rd} vignette for details: \code{vignette("rd", package = "roxygen2")}
+\item \code{knitr_chunk_options}: default chunk options used for knitr.
 }
 }
 


### PR DESCRIPTION
I think this would be useful to avoid repetition. I can try to write some test case. 