### PR TITLE
Only link to R6 superclass if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # roxygen2 (development version)
 
+* R6 only links to superclass docs if they're actually available (#1236).
+
 * You can now use alternative knitr engines in markdown code blocks (#1149).
 
 * Fix bug interpolating the results of indented inline RMarkdown (#1353).

--- a/R/rd-r6.R
+++ b/R/rd-r6.R
@@ -99,7 +99,13 @@ r6_superclass <- function(block, r6data, env) {
   push(paste0("\\section{", title, "}{"))
 
   pkgs <- super$classes$package[match(cls, super$classes$classname)]
-  path <- sprintf("\\code{\\link[%s:%s]{%s::%s}}", pkgs, cls, pkgs, cls)
+  has_topic <- purrr::map2_lgl(cls, pkgs, has_topic)
+
+  path <- ifelse(
+    has_topic,
+    sprintf("\\code{\\link[%s:%s]{%s::%s}}", pkgs, cls, pkgs, cls),
+    sprintf("\\code{%s::%s}", pkgs, cls)
+  )
   me <- sprintf("\\code{%s}", block$object$value$classname)
   push(paste(c(rev(path), me), collapse = " -> "))
 

--- a/R/utils-rd.R
+++ b/R/utils-rd.R
@@ -104,8 +104,9 @@ make_as_character_rd <- function() {
 has_topic <- function(topic, package) {
   tryCatch(
     {
-      out <- utils::help((topic), package = (package))
-      length(out) == 1
+      out <- inject(help(!!topic, !!package), global_env())
+      inherits(out, "dev_topic") ||
+        (inherits(out, "help_files_with_topic") && length(out) == 1)
     },
     error = function(c) FALSE
   )

--- a/tests/testthat/_snaps/rd-r6.md
+++ b/tests/testthat/_snaps/rd-r6.md
@@ -20,7 +20,7 @@
       cat(format(rd$get_section("rawRd")))
     Output
       \section{Super class}{
-      \code{\link[R_GlobalEnv:C1]{R_GlobalEnv::C1}} -> \code{C2}
+      \code{R_GlobalEnv::C1} -> \code{C2}
       }
       \section{Methods}{
       \subsection{Public methods}{

--- a/tests/testthat/roxygen-block-3-B.Rd
+++ b/tests/testthat/roxygen-block-3-B.Rd
@@ -11,7 +11,7 @@ Class B Description.
 Class B details.
 }
 \section{Super class}{
-\code{\link[roxygen2:A]{roxygen2::A}} -> \code{B}
+\code{roxygen2::A} -> \code{B}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}

--- a/tests/testthat/roxygen-block-3-C.Rd
+++ b/tests/testthat/roxygen-block-3-C.Rd
@@ -11,7 +11,7 @@ Class C Description.
 Classs C details.
 }
 \section{Super classes}{
-\code{\link[roxygen2:A]{roxygen2::A}} -> \code{\link[roxygen2:B]{roxygen2::B}} -> \code{C}
+\code{roxygen2::A} -> \code{roxygen2::B} -> \code{C}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}


### PR DESCRIPTION
Fixes #1236. Closes #1274.

This isn't perfect as you'll need to document twice if you document the class and superclass at the same time, but I think it's  a decent improvement.