### PR TITLE
use find.package() over system.file() to check installed

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -166,7 +166,7 @@ uuid <- function(nchar = 8) {
 
 # https://github.com/r-lib/rlang/issues/1434
 is_installed <- function(x) {
-  !identical(system.file(package = x), "")
+  length(find.package(package = x, quiet = TRUE)) > 0
 }
 
 # quoting -----------------------------------------------------------------


### PR DESCRIPTION
More direct &  should be more readable (not clear if the upstream rlang issue is still a blocker)