### PR TITLE
remove last newline in `tags_metadata()` description column

### DIFF
--- a/R/tag-metadata.R
+++ b/R/tag-metadata.R
@@ -23,7 +23,7 @@ tags_metadata <- function() {
   meta <- yaml::read_yaml(yaml_path())
   data.frame(
     tag = map_chr(meta, "name"),
-    description = map_chr(meta, "description"),
+    description = sub("\n$", "", map_chr(meta, "description")),
     # \n not useful outside of RStudio
     template = sub("\n", "", map_chr(meta, "template")),
     vignette = map_chr(meta, "vignette", .default = NA),


### PR DESCRIPTION
```
> head(tags_metadata()$description)
[1] "Add additional aliases to the topic. Use `NULL` to suppress the default alias automatically generated by roxygen2."                 
[2] "Topic author(s), if different from the package author(s)."                                                                          
[3] "Manually override the backreference that points from the `.Rd` file back to the source `.R` file. Only needed when generating code."
[4] "Add additional keywords or phrases to be included in the `help.search()` index. Each `@concept` should be a single term or phrase." 
[5] "Document a function or method in the `destination` topic."                                                                          
[6] "A short description of the purpose of the function. Usually around a paragraph, but can be longer if needed." 
```
