### PR TITLE
Fix error when handling error

### DIFF
--- a/R/tag.R
+++ b/R/tag.R
@@ -120,11 +120,13 @@ roxy_tag_warning <- function(x, ...) {
 #' @export
 #' @rdname roxy_tag
 warn_roxy_tag <- function(tag, message, ...) {
-  message[[1]] <- paste0(
-    link_to(tag$file, tag$line), " @", tag$tag, " ",
-    if (is.null(tag$raw)) ("(automatically generated) "),
-    message[[1]]
-  )
+  if (!is.null(tag$file)) {
+    message[[1]] <- paste0(
+      link_to(tag$file, tag$line), " @", tag$tag, " ",
+      if (is.null(tag$raw)) ("(automatically generated) "),
+      message[[1]]
+    )
+  }
   cli::cli_warn(message, ..., .envir = parent.frame())
 }
 


### PR DESCRIPTION
Hi,

This patch prevents an "error while handling an error" improving usability.  It's not a full solution for the underlying issue, but it helps to prevent roxygen from raising an error that was being attempted to be turned into a warning and it gives a hint of what's related to the error to the user, so the user can find a solution.

### The problem

While running `devtools::document()` on an in-progress (private for now) package, I got a very unspecific error:

```
devtools::document()
ℹ Updating <pkg-name> documentation
Setting `RoxygenNote` to "7.2.1.9000"
ℹ Loading <pkg-name>
Error in basename(file) : 
  a character vector argument expected
```

### Quick diagnostic

I checked the `traceback()`.  It tells us that the error is triggered within the `error = ` handling part of a `tryCatch` block (11-15 in the traceback below), while trying to generate a warning. It felt like a bug was hitting me when I was at my most vulnerable.

```
> traceback()
22: basename(file)
21: paste0(basename(file), ":", line)
20: paste0("\033]8;", params, ";", url, ST, text, "\033]8;;", ST)
19: cli::style_hyperlink(paste0(basename(file), ":", line), paste0("file://", 
        file), params = c(line = line, col = 1))
18: paste0("[", cli::style_hyperlink(paste0(basename(file), ":", 
        line), paste0("file://", file), params = c(line = line, col = 1)), 
        "]")
17: link_to(tag$file, tag$line)
16: paste0(link_to(tag$file, tag$line), " @", tag$tag, " ", if (is.null(tag$raw)) ("(automatically generated) "), 
        message[[1]])
15: warn_roxy_tag(topic, "failed to parse argument specification", 
        parent = e)
14: value[[3L]](cond)
13: tryCatchOne(expr, names, parentenv, handlers[[1L]])
12: tryCatchList(expr, classes, parentenv, handlers)
11: tryCatch({
        parsed <- lapply(pieces, function(x) parse(text = x)[[1]])
        select_args(fun, parsed)
    }, error = function(e) {
        warn_roxy_tag(topic, "failed to parse argument specification", 
            parent = e)
        character()
    })
10: .f(.x[[1L]], .y[[1L]], ...)
9: map2(funs, inheritors$args, select_args_text, topic = topic)
8: fun(topic, self, ...)
7: topics$apply(inherit_dot_params, env = env)
6: topics_process_inherit(topics, env)
5: roclet_process.roclet_rd(X[[i]], ...)
4: FUN(X[[i]], ...)
3: lapply(roclets, roclet_process, blocks = blocks, env = env, base_path = base_path)
2: roxygen2::roxygenise(pkg$path, roclets)
1: devtools::document()
```

### Mitigation

I can't fully fix the issue due to time constraints, but I was able to see the issue was related to a `NULL` being passed to `basename()`. This patch roughly avoids the error by checking for `tag$file` not being `NULL`.

With the patch applied, the error message became a warning:

```
ℹ Loading <pkg-name>
Warning message:
failed to parse argument specification
Caused by error in `FUN()`:
! object '<variable-name> not found 
```

This patch still does not fully tell me where the error is coming from. However it
 - turns the error into a warning as it tried to and
 - hints me that the error is related to `<variable-name>` helping me to find where the error is.

While it's not perfect I hope it is an improvement worth merging, since it's small and it improves usability significantly.

### Underlying issue?

Thanks to this patch I looked at my recent changes related to `<variable-name>` and I was able to pin the underlying issue to a piece of code I had:

    #' @inheritDotParams myfunction -<variable-name1> -<variable-name2>

where, by my own mistake, `myfunction` did not have `<variable-name1>` nor `<variable-name2>` as arguments.

I'm not familiar enough with roxygen2 and I do not have the time right now to give a more specific error message. However I believe the mitigation is simple and reliable enough to help others so I decided to submit this pull request for you to review.

Thank you very much for your time and work.
