### PR TITLE
Use cli for hashing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     cli (>= 3.3.0),
     commonmark,
     desc (>= 1.2.0),
-    digest,
     knitr,
     methods,
     pkgload (>= 1.0.2),

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,10 +103,10 @@ same_contents <- function(path, contents) {
   }
   if (!file.exists(path)) return(FALSE)
 
-  text_hash <- digest::digest(contents, serialize = FALSE)
+  text_hash <- cli::hash_sha256(contents)
 
   path <- normalizePath(path, mustWork = TRUE)
-  file_hash <- digest::digest(file = path)
+  file_hash <- cli::hash_file_sha256(path)
 
   identical(text_hash, file_hash)
 }


### PR DESCRIPTION
Because it works on Windows network drive paths.

This uses a SHA256 hash, instead of MD5, because MD5 is only implemented in dev cli for files, but for the file sizes we use this does not matter. `cli::hash_file_sha256()` is almost as fast as `digest::digest()` for MD5, actually.

We don't use `tools::md5sum()` because it also has an issue with Windows paths:
https://bugs.r-project.org/show_bug.cgi?id=17633
Plus we would also need a way to hash strings.

Another alternative would be `rlang::hash_file()`, but rlang also does not currently have a function to hash strings.

Closes #1443.