### PR TITLE
[IN-1175]: warn when S3 methods are not tagged with @export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: roxygen2
 Title: In-Line Documentation for R
-Version: 7.2.3.9000
+Version: 7.2.3.10000
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-4757-117X")),


### PR DESCRIPTION
https://github.com/r-lib/roxygen2/issues/1175