### PR TITLE
Use plain markdown language tag for gated code over eval=FALSE

### DIFF
--- a/vignettes/namespace.Rmd
+++ b/vignettes/namespace.Rmd
@@ -85,7 +85,7 @@ The `NAMESPACE` also controls which functions from other packages are made avail
 
 If you are using just a few functions from another package, we recommending adding the package to the `Imports:` field of the `DESCRIPTION` file and calling the functions explicitly using `::`, e.g., `pkg::fun()`.
 
-```{r, eval = FALSE}
+```r
 my_function <- function(x, y) {
   pkg::fun(x) * y
 }

--- a/vignettes/namespace.Rmd
+++ b/vignettes/namespace.Rmd
@@ -93,7 +93,7 @@ my_function <- function(x, y) {
 
 If the repetition of the package name becomes annoying you can `@importFrom` and drop the `::`:
 
-```{r}
+```r
 #' @importFrom pkg fun 
 my_function <- function(x, y) {
   fun(x) * y


### PR DESCRIPTION
This chunk throws a lint error for me (under `object_usage_linter()`) that I'd like to suppress.

It's suggested here to avoid `eval=FALSE`:

https://github.com/r-lib/lintr/issues/581#issuecomment-1159770660

That's far from canon, but it does make sense to me.

If not, we'll need to revisit the {lintr} issue and come up with a better approach for handling `eval=FALSE` -- any advice in that direction would be helpful. I only saw `knitr:::parse_params()` which seems fragile.

Feedback welcome.