### PR TITLE
remove duplicated text (belonging to output rather than examples)

### DIFF
--- a/vignettes/rd.Rmd
+++ b/vignettes/rd.Rmd
@@ -129,8 +129,6 @@ This way, the code evaluating whether the example can be run is not shown to use
 
 Instead of including examples directly in the documentation, you can put them in separate files and use `@example path/relative/to/package/root` to insert them into the documentation.
 
-All functions must have a documented return value for initial CRAN submission.
-
 ### Usage
 
 In most case, the function usage (which appears beneath the description in the generates docs) will be automatically derived from the function specification.


### PR DESCRIPTION
The removed text belongs to the output section rather than the examples one.