### PR TITLE
Ignore self-import directives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 (development version)
 
+* The `ROXYGEN_PKG` environment variable is now set up while roxygen
+  is running to the name of the package being documented (#1517).
+
 * Import directives are now ignored if they try to import from the
   package being documented. This is useful to add self-dependencies in
   standalone files meant to be used in other packages (r-lib/usethis#1853).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # roxygen2 (development version)
 
+* Import directives are now ignored if they try to import from the
+  package being documented. This is useful to add self-dependencies in
+  standalone files meant to be used in other packages (r-lib/usethis#1853).
+
 # roxygen2 7.2.3
 
 * roxygen2 now supports HTML blocks in markdown. They are only included

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -326,7 +326,7 @@ repeat_first <- function(name, x) {
 }
 
 one_per_line_ignore_current <- function(name, x) {
-  current <- getOption("roxygen2:::package")
+  current <- peek_roxygen_pkg()
 
   # Ignore any occurrence of `current` inside `x`
   if (is_string(current)) {
@@ -336,7 +336,7 @@ one_per_line_ignore_current <- function(name, x) {
   one_per_line(name, x)
 }
 repeat_first_ignore_current <- function(name, x) {
-  current <- getOption("roxygen2:::package")
+  current <- peek_roxygen_pkg()
 
   # Ignore the whole command if "first" is `current`
   if (is_string(current) && length(x) && x[[1]] == current) {

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -220,7 +220,7 @@ roxy_tag_parse.roxy_tag_import <- function(x) {
 }
 #' @export
 roxy_tag_ns.roxy_tag_import <- function(x, block, env, import_only = FALSE) {
-  one_per_line("import", x$val)
+  one_per_line_ignore_current("import", x$val)
 }
 
 #' @export
@@ -229,7 +229,7 @@ roxy_tag_parse.roxy_tag_importClassesFrom <- function(x) {
 }
 #' @export
 roxy_tag_ns.roxy_tag_importClassesFrom <- function(x, block, env, import_only = FALSE) {
-  repeat_first("importClassesFrom", x$val)
+  repeat_first_ignore_current("importClassesFrom", x$val)
 }
 
 #' @export
@@ -238,7 +238,7 @@ roxy_tag_parse.roxy_tag_importFrom <- function(x) {
 }
 #' @export
 roxy_tag_ns.roxy_tag_importFrom <- function(x, block, env, import_only = FALSE) {
-  repeat_first("importFrom", x$val)
+  repeat_first_ignore_current("importFrom", x$val)
 }
 
 #' @export
@@ -247,7 +247,7 @@ roxy_tag_parse.roxy_tag_importMethodsFrom <- function(x) {
 }
 #' @export
 roxy_tag_ns.roxy_tag_importMethodsFrom <- function(x, block, env, import_only = FALSE) {
-  repeat_first("importMethodsFrom", x$val)
+  repeat_first_ignore_current("importMethodsFrom", x$val)
 }
 
 #' @export
@@ -315,10 +315,35 @@ export_s3_method <- function(x) {
 }
 
 one_per_line <- function(name, x) {
-  paste0(name, "(", auto_quote(x), ")")
+  if (length(x)) {
+    paste0(name, "(", auto_quote(x), ")")
+  } else {
+    NULL
+  }
 }
 repeat_first <- function(name, x) {
   paste0(name, "(", auto_quote(x[1]), ",", auto_quote(x[-1]), ")")
+}
+
+one_per_line_ignore_current <- function(name, x) {
+  current <- getOption("roxygen2:::package")
+
+  # Ignore any occurrence of `current` inside `x`
+  if (is_string(current)) {
+    x <- x[x != current]
+  }
+
+  one_per_line(name, x)
+}
+repeat_first_ignore_current <- function(name, x) {
+  current <- getOption("roxygen2:::package")
+
+  # Ignore the whole command if "first" is `current`
+  if (is_string(current) && length(x) && x[[1]] == current) {
+    NULL
+  } else {
+    repeat_first(name, x)
+  }
 }
 
 namespace_exports <- function(path) {

--- a/R/roxygenize-setup.R
+++ b/R/roxygenize-setup.R
@@ -25,12 +25,22 @@ roxygen_setup <- function(path = ".",
   man_path <- file.path(path, "man")
   dir.create(man_path, recursive = TRUE, showWarnings = FALSE)
 
-  local_options(
-    "roxygen2:::package" = desc::desc_get("Package", path),
-    .frame = frame
+  withr::local_envvar(
+    ROXYGEN_PKG = desc::desc_get("Package", path),
+    .local_envir = frame
   )
 
   is_first
+}
+
+peek_roxygen_pkg <- function() {
+  pkg <- Sys.getenv("ROXYGEN_PKG")
+
+  if (nzchar(pkg)) {
+    pkg
+  } else {
+    NULL
+  }
 }
 
 update_roxygen_version <- function(path, cur_version = NULL) {

--- a/R/roxygenize-setup.R
+++ b/R/roxygenize-setup.R
@@ -1,4 +1,6 @@
-roxygen_setup <- function(path = ".", cur_version = NULL) {
+roxygen_setup <- function(path = ".",
+                          cur_version = NULL,
+                          frame = caller_env()) {
   if (!file.exists(file.path(path, "DESCRIPTION"))) {
     cli::cli_abort(
       "{.arg package.dir} ({.path {path}}) does not contain a DESCRIPTION"
@@ -22,6 +24,11 @@ roxygen_setup <- function(path = ".", cur_version = NULL) {
 
   man_path <- file.path(path, "man")
   dir.create(man_path, recursive = TRUE, showWarnings = FALSE)
+
+  local_options(
+    "roxygen2:::package" = desc::desc_get("Package", path),
+    .frame = frame
+  )
 
   is_first
 }

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -204,7 +204,7 @@ test_that("other namespace tags produce correct output", {
 })
 
 test_that("import directives for current package are ignored", {
-  local_options("roxygen2:::package" = "ignored")
+  withr::local_envvar(c("ROXYGEN_PKG" = "ignored"))
 
   out <- roc_proc_text(namespace_roclet(), "
     #' @import ignored

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -203,6 +203,23 @@ test_that("other namespace tags produce correct output", {
   )))
 })
 
+test_that("import directives for current package are ignored", {
+  local_options("roxygen2:::package" = "ignored")
+
+  out <- roc_proc_text(namespace_roclet(), "
+    #' @import ignored
+    #' @import test ignored test2
+    #' @importFrom ignored test1 test2
+    #' @importClassesFrom ignored test1 test2
+    #' @importMethodsFrom ignored test1 test2
+    NULL")
+
+  expect_equal(sort(out), sort(c(
+    "import(test)",
+    "import(test2)"
+  )))
+})
+
 test_that("poorly formed importFrom throws error", {
   expect_snapshot_warning(roc_proc_text(namespace_roclet(), "
     #' @importFrom test


### PR DESCRIPTION
If I'm not missing anything that's all that is needed to provide a solution for https://github.com/r-lib/usethis/issues/1853. With this PR, an `#' @import(foo)` directive is ignored when documenting the package foo. This makes it possible for standalone files to define their self dependencies.