### PR TITLE
Fix typo `@keyword` -> `@keywords` and `@ExamplesIf` snippet

### DIFF
--- a/inst/roxygen2-tags.yml
+++ b/inst/roxygen2-tags.yml
@@ -102,7 +102,7 @@
 - name: examplesIf
   description: >
     Run examples only when `condition` is `TRUE`.
-  template: " ${1:condition}\n${1:# example code}\n"
+  template: " ${1:condition}\n${2:# example code}\n"
   vignette: rd
   recommend: true
 

--- a/inst/roxygen2-tags.yml
+++ b/inst/roxygen2-tags.yml
@@ -240,7 +240,7 @@
 - name: keywords
   description: >
     Add a standardised keyword, indexed by `help.search()`. These are generally
-    not useful apart from `@keyword internal` which flags the topic as internal
+    not useful apart from `@keywords internal` which flags the topic as internal
     and removes from topic indexes.
   template: ' ${1:keyword}'
   vignette: index-crossref


### PR DESCRIPTION
Update roxygen2-tags.yml
because I get the warning.

`@keyword is not a known tag `

Edit: this typo appears in reference and in RStudio IDE autocomplete.

Edit 2: snapshot failures unrelated