### PR TITLE
qualify rlang ns in test

### DIFF
--- a/tests/testthat/helper-test.R
+++ b/tests/testthat/helper-test.R
@@ -16,7 +16,7 @@ expect_parse_failure <- function(code)  {
   (expect_warning(expect_null(code)))
 }
 
-local_package_copy <- function(path, env = caller_env(), set_version = TRUE) {
+local_package_copy <- function(path, env = rlang::caller_env(), set_version = TRUE) {
   temp_path <- withr::local_tempdir(.local_envir = env)
 
   file.copy(path, temp_path, recursive = TRUE)


### PR DESCRIPTION
Had the test suite fail for several reasons, one of which was 'caller_env not found'. It's in `roxygen2`'s namespace (via `import(rlang)`), but I think it's preferable to only rely on roxygen2's own objects in the tests without qualification/attachment.