### PR TITLE
Support `@exportS3Method NULL`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,8 @@
 * The NAMESPACE roclet now reports if you have S3 methods that are missing
   an `@export` tag. All S3 methods need to be `@export`ed (which confusingly
   really registers the method) even if the generic is not. This avoids rare,
-  but hard to debug, problems (#1175).
+  but hard to debug, problems (#1175). You can suppress the warning with
+  `@exportS3Method NULL` (#1550).
 
 * `@include` now gives an informative warning if you use a path that doesn't
   exist (#1497).

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -199,6 +199,10 @@ roxy_tag_parse.roxy_tag_exportS3Method <- function(x) {
 roxy_tag_ns.roxy_tag_exportS3Method <- function(x, block, env) {
   obj <- block$object
 
+  if (identical(x$val, "NULL")) {
+    return()
+  }
+
   if (identical(x$val, "")) {
     if (!inherits(obj, "s3method")) {
       warn_roxy_tag(x, "must be used with an known S3 method")

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -437,6 +437,17 @@ test_that("warns if S3 method not documented", {
   )
 })
 
+
+test_that("can suppress the warning", {
+  block <- "
+    #' @exportS3Method NULL
+    mean.myclass <- function(x) 1
+  "
+  expect_silent(out <- roc_proc_text(namespace_roclet(), block))
+  expect_equal(out, character())
+})
+
+
 test_that("doesn't warn for potential false postives", {
   roc <- namespace_roclet()
   expect_no_warning({

--- a/vignettes/namespace.Rmd
+++ b/vignettes/namespace.Rmd
@@ -72,6 +72,8 @@ bizarro.character <- function(x, ...) {
 }
 ```
 
+If you are exporting a method in some other way, you can use `@exportS3Method NULL` to suppress the warning.
+
 You have four options for documenting an S3 method:
 
 -   Don't document it; it's not required, and not needed for simple generics where the user won't care about the details.


### PR DESCRIPTION
To suppress the S3 method warning message. Fixes #1550.