### PR TITLE
Non-syntactic S4 classes don't need backticks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # roxygen2 (development version)
 
+* Generate correct usage for S4 methods with non-syntactic class names.
+
 * `@describeIn foo` now suggests that you might want `@rdname` instead 
   (#1493).
 

--- a/R/rd-usage.R
+++ b/R/rd-usage.R
@@ -60,7 +60,7 @@ object_usage.s4generic <- function(x) {
 #' @export
 object_usage.s4method <- function(x) {
   s4method <- function(name) {
-    classes <- auto_backtick(as.character(x$value@defined))
+    classes <- as.character(x$value@defined)
     paste0("\\S4method{", name, "}{", paste0(classes, collapse = ","), "}")
   }
   function_usage(x$value@generic, formals(x$value), s4method)

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -251,13 +251,13 @@ test_that("default usage correct for S4 methods with different args to generic",
   )
 })
 
-test_that("non-syntactic S4 class names are escaped in usage", {
+test_that("non-syntactic S4 class names are not escaped in usage", {
   expect_equal(
     call_to_usage({
       setGeneric("rhs", function(x) standardGeneric("rhs"))
       setMethod("rhs", "<-", function(x) x[[3]])
     }),
-    "\\S4method{rhs}{`<-`}(x)"
+    "\\S4method{rhs}{<-}(x)"
   )
 })
 


### PR DESCRIPTION
Fixes documentation issue in odbc