### PR TITLE
Add a .devcontainer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,7 @@
 ^\.github$
 ^pkgdown$
 ^\.covrignore$
+^\.devcontainer$
 ^azure-pipelines\.yml$
 ^\.Rprofile$
 ^r-packages$

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM rocker/r-base
+
+RUN apt-get -qq update && \
+  apt-get install -y --no-install-recommends git libxml2-dev
+
+COPY DESCRIPTION .
+
+RUN Rscript -e '                           \
+  install.packages("remotes");             \
+  remotes::install_deps(dependencies = c(  \
+    "Imports",                             \
+    "Config/Needs/development"             \
+  ))                                       \
+'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN Rscript -e '                           \
   install.packages("remotes");             \
   remotes::install_deps(dependencies = c(  \
     "Imports",                             \
+    "LinkingTo",                           \
     "Config/Needs/development"             \
   ))                                       \
 '

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "build": { "dockerfile": "Dockerfile", "context": ".."}
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ LinkingTo:
     cpp11
 VignetteBuilder: 
     knitr
+Config/Needs/development: testthat
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE


### PR DESCRIPTION
This allows users to develop roxygen2 directly from the browser with GitHub Codespaces.

One nice side effect is encapsulating (in the Dockerfile) the minimal setup needed to get roxygen2 prepared for development locally.

Config/Needs/development is a way to strike a balance between installing all of Imports+Suggests (takes longer to build the container) and missing some pieces essential to development (testthat's a good example -- you can't really do most dev work without running the test suite --> need testthat).

In {lintr}, we also added {pkgload} here since that is used a lot in dev workflow. ({roxygen2} already Imports {pkgload}, of course):

https://github.com/r-lib/lintr/blob/bad1632f23b77f41cec13fb6f1c883302f64f506/DESCRIPTION#L55