### PR TITLE
Correctly interpolate dangerous string into cli warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,4 @@ Config/testthat/parallel: TRUE
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE, load = "installed")
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.0.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # roxygen2 (development version)
 
+* S3 method export warning no longer fails if class contains `{` or `}` (#1575).
+
 * `@family` lists are now ordered more carefully, "foo1" comes after "foo" (#1563, @krlmlr).
+
 * Re-runs of `namespace_roclet()` fixed for packages using multi-line `@rawNamespace` directives (#1572, @MichaelChirico).
 
 * `@importFrom` works again for quoted non-syntactic names, e.g.

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -401,7 +401,11 @@ warn_missing_s3_exports <- function(blocks, env) {
 
   undocumented <- methods[!methods %in% s3objects]
   srcrefs <- map(undocumented, attr, "srcref")
-  messages <- paste0("S3 method `", names(undocumented) , "` needs @export or @exportS3method tag")
-  map2(undocumented, messages, warn_roxy_function)
-}
 
+  map2(undocumented, names(undocumented), function(fun, name) {
+    warn_roxy_function(
+      fun,
+      "S3 method {.arg {name}} needs @export or @exportS3method tag"
+    )
+  })
+}

--- a/tests/testthat/_snaps/namespace.md
+++ b/tests/testthat/_snaps/namespace.md
@@ -95,21 +95,15 @@
 # warns if S3 method not documented
 
     Code
-      roc_proc_text(namespace_roclet(),
-      "\n      foo <- function(x) UseMethod('foo')\n      foo.numeric <- function(x) 1\n\n      mean.myclass <- function(x) 2\n    ")
+      . <- roc_proc_text(namespace_roclet(), block)
     Message
       x <text>:5: S3 method `mean.myclass` needs @export or @exportS3method tag.
       x <text>:3: S3 method `foo.numeric` needs @export or @exportS3method tag.
-    Output
-      character(0)
 
-# correctly interpolates warning
+---
 
     Code
-      roc_proc_text(namespace_roclet(),
-      "\n      foo <- function(x) UseMethod('foo')\n      `foo.{` <- function(x) 1\n    ")
+      . <- roc_proc_text(namespace_roclet(), block)
     Message
       x <text>:3: S3 method `foo.{` needs @export or @exportS3method tag.
-    Output
-      character(0)
 

--- a/tests/testthat/_snaps/namespace.md
+++ b/tests/testthat/_snaps/namespace.md
@@ -103,3 +103,13 @@
     Output
       character(0)
 
+# correctly interpolates warning
+
+    Code
+      roc_proc_text(namespace_roclet(),
+      "\n      foo <- function(x) UseMethod('foo')\n      `foo.{` <- function(x) 1\n    ")
+    Message
+      x <text>:3: S3 method `foo.{` needs @export or @exportS3method tag.
+    Output
+      character(0)
+

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -472,31 +472,31 @@ test_that("non-syntactic imports can use multiple quoting forms", {
 # warn_missing_s3_exports -------------------------------------------------
 
 test_that("warns if S3 method not documented", {
-  expect_snapshot(
-    roc_proc_text(namespace_roclet(), "
+  # Need to manually transform since the srcref is coming from the function;
+  # roc_proc_text() uses fake srcrefs for the blocks themselves
+  fix_srcref <- function(x) gsub("file[a-z0-9]+", "<text>", x)
+
+  block <- "
       foo <- function(x) UseMethod('foo')
       foo.numeric <- function(x) 1
 
       mean.myclass <- function(x) 2
-    "),
-    # Need to manually transform since the srcref is coming from the function;
-    # roc_proc_text() uses fake srcrefs for the blocks themselves
-    transform = function(x) gsub("file[a-z0-9]+", "<text>", x)
-  )
-})
-
-test_that("correctly interpolates warning", {
+    "
   expect_snapshot(
-    roc_proc_text(namespace_roclet(), "
-      foo <- function(x) UseMethod('foo')
-      `foo.{` <- function(x) 1
-    "),
-    # Need to manually transform since the srcref is coming from the function;
-    # roc_proc_text() uses fake srcrefs for the blocks themselves
-    transform = function(x) gsub("file[a-z0-9]+", "<text>", x)
+    . <- roc_proc_text(namespace_roclet(), block),
+    transform = fix_srcref
+  )
+
+  # Works even if method contains {
+  block <- "
+    foo <- function(x) UseMethod('foo')
+    `foo.{` <- function(x) 1
+  "
+  expect_snapshot(
+    . <- roc_proc_text(namespace_roclet(), block),
+    transform = fix_srcref
   )
 })
-
 
 test_that("can suppress the warning", {
   block <- "

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -485,6 +485,18 @@ test_that("warns if S3 method not documented", {
   )
 })
 
+test_that("correctly interpolates warning", {
+  expect_snapshot(
+    roc_proc_text(namespace_roclet(), "
+      foo <- function(x) UseMethod('foo')
+      `foo.{` <- function(x) 1
+    "),
+    # Need to manually transform since the srcref is coming from the function;
+    # roc_proc_text() uses fake srcrefs for the blocks themselves
+    transform = function(x) gsub("file[a-z0-9]+", "<text>", x)
+  )
+})
+
 
 test_that("can suppress the warning", {
   block <- "


### PR DESCRIPTION
Fixes #1575