### PR TITLE
Use more generic `x-r-run` over `ide:run`

### DIFF
--- a/R/rd.R
+++ b/R/rd.R
@@ -60,14 +60,14 @@ roclet_output.roclet_rd <- function(x, results, base_path, ..., is_first = FALSE
 
   names <- unname(map_chr(results, ~ .$get_name()[[1]]))
   if (length(names) > 0) {
-    hrefs <- paste0("ide:run:pkgload::dev_help('", names, "')")
+    commands <- paste0("pkgload::dev_help('", names, "')")
   } else {
-    hrefs <- character()
+    commands <- character()
   }
 
   # Always check for roxygen2 header before overwriting NAMESPACE (#436),
   # even when running for the first time
-  mapply(write_if_different, paths, contents, href = hrefs)
+  mapply(write_if_different, paths, contents, command = commands)
 
   if (!is_first) {
     # Automatically delete any files in man directory that were generated

--- a/R/utils.R
+++ b/R/utils.R
@@ -61,7 +61,7 @@ nice_name <- function(x) {
   x
 }
 
-write_if_different <- function(path, contents, href = NULL, check = TRUE) {
+write_if_different <- function(path, contents, command = NULL, check = TRUE) {
   if (!file.exists(dirname(path))) {
     dir.create(dirname(path), showWarnings = FALSE)
   }
@@ -87,8 +87,10 @@ write_if_different <- function(path, contents, href = NULL, check = TRUE) {
     ))
     FALSE
   } else {
-    if (!is.null(href)) {
-      name <- cli::style_hyperlink(name, href)
+    if (!is.null(command)) {
+      scheme <- "x-r-run"
+      url <- paste0(scheme, ":", command)
+      name <- cli::style_hyperlink(name, url)
     }
     cli::cli_inform("Writing {.path {name}}")
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -27,3 +27,12 @@
     Output
       [1] FALSE
 
+# write_if_different produces correct command hyperlink
+
+    Code
+      write_if_different(path, "a <- 2", command = "rlang::inform('hi')")
+    Message
+      Writing ']8;;x-r-run:rlang::inform('hi')test.R]8;;'
+    Output
+      [1] TRUE
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -68,3 +68,13 @@ test_that("write_if_different and end of line", {
   expect_message(write_if_different(tmp, cnt_mix, check = FALSE), "Writing ")
   expect_identical(readBin(tmp, "raw", 100), readBin(tmp_win, "raw", 100))
 })
+
+test_that("write_if_different produces correct command hyperlink", {
+  testthat::local_reproducible_output(hyperlinks = TRUE)
+
+  dir <- withr::local_tempdir()
+  path <- file.path(dir, "test.R")
+
+  write_lines(made_by("#"), path)
+  expect_snapshot(write_if_different(path, "a <- 2", command = "rlang::inform('hi')"))
+})


### PR DESCRIPTION
I was going to switch us away from `style_hyperlink()` entirely in favor of `format_inline("{.run ...}")`, but it produces some weird text when in the fallback case

- `style_hyperlink()` returns `text` unchanged in the fallback case
- `.run {text}` returns `text` styled as `{.code }` in the fallback case, i.e. it backticks it

So in the fallback case, if you combine `.run {text}` (backticks) with our usage of `{.path }` (single quotes) below, then you end up with ```` Writing '`a.Rd`' ````. It seems better to just continue to manually use `style_hyperlink()` so we have complete control over the fallback view. This case is covered by a test, which is how I learned about it in the first place.

https://github.com/r-lib/roxygen2/blob/db4dd9a4de2ce6817c17441d481cf5d03ef220e2/R/utils.R#L90-L93