### PR TITLE
Support Markdown in custom `@family` titles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # roxygen2 (development version)
 
+* Custom [`@family`
+  titles](https://roxygen2.r-lib.org/articles/index-crossref.html) now support
+  Markdown syntax (#1608, @salim-b).
+
 # roxygen2 7.3.1
 
 * S3 method export warning no longer fails if class contains `{` or `}` (#1575).

--- a/R/rd-family.R
+++ b/R/rd-family.R
@@ -31,8 +31,7 @@ topics_process_family_prefix <- function(family) {
   if (is.null(prefix))
     return(default)
 
-  prefix
-
+  markdown(prefix, tag = "family")
 }
 
 topics_process_family <- function(topics, env) {

--- a/tests/testthat/test-rd-family.R
+++ b/tests/testthat/test-rd-family.R
@@ -124,6 +124,22 @@ test_that("custom family prefixes can be set", {
   expect_match(out$get_value("seealso"), "^Custom prefix:")
 })
 
+test_that("custom family prefixes can include Markdown", {
+
+  local_roxy_meta_set("rd_family_title", list(a = "Custom ***strongly emphasized*** prefix: "))
+  out <- roc_proc_text(rd_roclet(), "
+    #' foo
+    #' @family a
+    foo <- function() {}
+
+    #' bar
+    #' @family a
+    bar <- function() {}
+  ")[[1]]
+
+  expect_match(out$get_value("seealso"), "^Custom \\\\emph\\{\\\\strong\\{strongly emphasized\\}} prefix:")
+})
+
 test_that("careful ordering", {
   out <- roc_proc_text(rd_roclet(), "
     #' foo1


### PR DESCRIPTION
Parses [custom `@family` titles](https://roxygen2.r-lib.org/articles/index-crossref.html) as Markdown.