### PR TITLE
Set `cli.hyperlink = FALSE` in `local_reproducible_output()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 (development version)
 
+* `@includeRmd` now additionally sets `options(cli.hyperlink = FALSE)` to make
+  code run in included `.Rmd`s even more consistent across sessions (#1620).
+
 # roxygen2 7.3.1
 
 * S3 method export warning no longer fails if class contains `{` or `}` (#1575).

--- a/R/rd-eval.R
+++ b/R/rd-eval.R
@@ -17,6 +17,7 @@ local_reproducible_output <- function(.envir = parent.frame()) {
     crayon.enabled = FALSE,
     cli.unicode = FALSE,
     cli.dynamic = FALSE,
+    cli.hyperlink = FALSE,
     rlang_interactive = FALSE,
     width = 80,
     .local_envir = .envir


### PR DESCRIPTION
Closes https://github.com/r-lib/roxygen2/issues/1620

Like we do in the testthat version