### PR TITLE
Set language to english in `local_reproducible_output()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # roxygen2 (development version)
 
-* `@includeRmd` now additionally sets `options(cli.hyperlink = FALSE)` to make
+* `@includeRmd` now additionally sets `options(cli.hyperlink = FALSE)` and language = English to make
   code run in included `.Rmd`s even more consistent across sessions (#1620).
 
 # roxygen2 7.3.1

--- a/R/rd-eval.R
+++ b/R/rd-eval.R
@@ -23,5 +23,9 @@ local_reproducible_output <- function(.envir = parent.frame()) {
     .local_envir = .envir
   )
   withr::local_envvar(RSTUDIO = NA, .local_envir = .envir)
+  if (isTRUE(capabilities("NLS")) && Sys.getenv("LANG") !=
+      "C") {
+    withr::local_language("en", .local_envir = .envir)
+  }
   withr::local_collate("C", .local_envir = .envir)
 }


### PR DESCRIPTION
Addresses #1619.

Probably need to find a better way to respect language set in DESCRIPTION, any way to access this?

Similar to the approach in #1621 