### PR TITLE
Resolve markdown links to external packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * Custom [`@family`
   titles](https://roxygen2.r-lib.org/articles/index-crossref.html) now support
   Markdown syntax (#1608, @salim-b).
+
+* Unqualified markdown links to topics in external packages are now
+  automatically resolved (#1612).
+
 # roxygen2 7.3.2
 
 * `@includeRmd` now additionally sets `options(cli.hyperlink = FALSE)` to make
@@ -16,7 +20,7 @@
   (#1563, @krlmlr).
 
 * `@importFrom` works again for quoted non-syntactic names, e.g.
-  `@importFrom magrittr "%>%"` or ``@importFrom rlang `:=` `` 
+  `@importFrom magrittr "%>%"` or ``@importFrom rlang `:=` ``
   (#1570, @MichaelChirico). The unquoted form `@importFrom magrittr %>%`
   continues to work. Relatedly, `@importFrom` directives matching no known
   functions (e.g. `@importFrom utils plot pdf`) produce valid NAMESPACE files
@@ -29,11 +33,11 @@
 
 ## New features
 
-* `@docType package` now works more like documenting `"_PACKAGE"`, 
+* `@docType package` now works more like documenting `"_PACKAGE"`,
   creating a `{packagename}-package` alias and clearly suggesting that
   you should switch to `"_PACKAGE"` instead (#1491).
 
-* `_PACKAGE` will no longer generate an alias for your package name if 
+* `_PACKAGE` will no longer generate an alias for your package name if
   a function of the same name exists (#1160).
 
 * The NAMESPACE roclet now reports if you have S3 methods that are missing
@@ -41,32 +45,32 @@
   really registers the method) even if the generic is not. This avoids rare,
   but hard to debug, problems (#1175). You can suppress the warning with
   `@exportS3Method NULL` (#1550).
-  
-* The `NAMESPACE` roclet once again regenerates imports _before_ loading 
-  package code and parsing roxygen blocks. This has been the goal for a long 
-  time (#372), but we accidentally broke it when adding support for code 
+
+* The `NAMESPACE` roclet once again regenerates imports _before_ loading
+  package code and parsing roxygen blocks. This has been the goal for a long
+  time (#372), but we accidentally broke it when adding support for code
   execution in markdown blocks. This resolves a family of problems where you
   somehow bork your `NAMESPACE` and can't easily get out of it because you
   can't re-document the package because your code doesn't reload.
 
 ## Minor improvements and bug fixes
 
-* If you document a function from another package it is automatically 
-  imported. Additionally, if you set `@rdname` or `@name` you can opt out 
-  of the default `reexports` topic generation and provide your own docs 
+* If you document a function from another package it is automatically
+  imported. Additionally, if you set `@rdname` or `@name` you can opt out
+  of the default `reexports` topic generation and provide your own docs
   (#1408).
 
 * Generate correct usage for S4 methods with non-syntactic class names.
 
 * The `ROXYGEN_PKG` env var provides the name of the package being documented
   (#1517).
-  
-* `@describeIn foo` now suggests that you might want `@rdname` instead 
+
+* `@describeIn foo` now suggests that you might want `@rdname` instead
   (#1493). It also gives a more informative warning if you use it with an
   unsupported type (#1490).
 
-* In `DESCRIPTION`, URLs containing escapes in `URL` and `BugReports` are 
-  now correctly handled (@HenningLorenzen-ext-bayer, #1415). Authors can now 
+* In `DESCRIPTION`, URLs containing escapes in `URL` and `BugReports` are
+  now correctly handled (@HenningLorenzen-ext-bayer, #1415). Authors can now
   have multiple email addresses (@jmbarbone, #1487).
 
 * `escape_examples()` is now exported (#1450).
@@ -74,7 +78,7 @@
 * `@exportS3Method` provides the needed metadata to generate correct usage
   for S3 methods, just like `@method` (#1202).
 
-* `is_s3_generic()` now ignores non-function objects when looking for a 
+* `is_s3_generic()` now ignores non-function objects when looking for a
   candidate function. I believe this is closer to how R operates.
 
 * `@import` and friends are now ignored if they try to import from the
@@ -87,7 +91,7 @@
 * `@include` now gives an informative warning if you use a path that doesn't
   exist (#1497).
 
-* `@inherit` can now also inherit from `@format` (#1293). 
+* `@inherit` can now also inherit from `@format` (#1293).
 
 # roxygen2 7.2.3
 
@@ -109,22 +113,22 @@
 ## Tags
 
 * All built-in tags are now documented so that you can do (e.g.) `?"@param"`
-  to get a basic description of `@param` and a pointer where to learn more 
-  (#1165). This is powered by a new `tags_list()` lists all tags defined by 
-  roxygen2 and `tags_metadata()` provides some useful information about them 
+  to get a basic description of `@param` and a pointer where to learn more
+  (#1165). This is powered by a new `tags_list()` lists all tags defined by
+  roxygen2 and `tags_metadata()` provides some useful information about them
   for use by (e.g.) IDEs (#1375).
 
 * `@describeIn` can now be used to combine more types of functions
   (generics, methods and other functions) into a single topic.
   The resulting section organises the functions by type (#1181)
-  and displays methods like function calls. Methods are recognized only if 
-  they extend the generic in the destination,or if the destination can 
+  and displays methods like function calls. Methods are recognized only if
+  they extend the generic in the destination,or if the destination can
   heuristically be identified as a constructor.
 
 * Code evaluated in inline markdown code chunks and `@eval`/`@evalRd`/
   `@evalNamespace` is now evaluated in an environment designed to be more
   reproducible and to suppress output that won't work in Rd (e.g. turning
-  off colour and unicode support in cli) (#1351). They now also set 
+  off colour and unicode support in cli) (#1351). They now also set
   knitr options `comment = #>` (#1380) and `collapse = TRUE` (#1376).
 
 * `@export` will now export both the class and constructor function when
@@ -138,15 +142,15 @@
   `DESCRIPTION` or in `man/roxygen/meta.R`) is added to the knitr chunk
   options that roxygen2 uses for markdown code blocks and inline
   code (#1390).
-  
+
 * PDF figures are only included the PDF manual, and SVG figures are only
   included in the HTML manual (#1399).
 
 * You can now use alternative knitr engines in markdown code blocks (#1149).
 
-* Generated HTML for code blocks never includes "NA" for language (#1251). 
+* Generated HTML for code blocks never includes "NA" for language (#1251).
 
-* Using a level 1 heading in the wrong tag now gives a more useful warning 
+* Using a level 1 heading in the wrong tag now gives a more useful warning
   (#1374).
 
 * Fix bug interpolating the results of indented inline RMarkdown (#1353).
@@ -157,8 +161,8 @@
   now clickable so you can immediately see the rendered development
   documentation (#1354).
 
-* R6 documentation no longer shows inherited methods if there aren't any 
-  (#1371), and only links to superclass docs if they're actually available 
+* R6 documentation no longer shows inherited methods if there aren't any
+  (#1371), and only links to superclass docs if they're actually available
   (#1236).
 
 * Automated usage no longer mangles nbsp in default arguments (#1342).
@@ -175,16 +179,16 @@
   inheriting from a function with `@param x,y` you'll only get the parameter
   documentation if your function needs docs for both x and y (#950).
 
-* All warning messages have been reviewed to be more informative and 
+* All warning messages have been reviewed to be more informative and
   actionable (#1317). `@title` now checks for multiple paragraphs.
-  `@export` gives a more informative warning if it contains too many lines. 
-  (#1074). All tags warn now if only provide whitespace (#1228), and 
-  problems with the first tag in each block are reported with the correct line 
+  `@export` gives a more informative warning if it contains too many lines.
+  (#1074). All tags warn now if only provide whitespace (#1228), and
+  problems with the first tag in each block are reported with the correct line
   number (#1235).
 
-* If you have a daily build of RStudio, roxygen2 warnings will now include a 
+* If you have a daily build of RStudio, roxygen2 warnings will now include a
   clickable hyperlink that will take you directly to the problem (#1323).
-  This technology is under active development across the IDE and the cli 
+  This technology is under active development across the IDE and the cli
   package but is extremely exciting.
 
 ## Minor improvements and bug fixes
@@ -193,39 +197,39 @@
 
 * `@author`s are de-duplicated in merged documentation (@DanChaltiel, #1333).
 
-* `@exportS3Method pkg::generic` now works when `pkg::generic` isn't 
+* `@exportS3Method pkg::generic` now works when `pkg::generic` isn't
   imported by your package (#1085).
 
-* `@includeRmd` is now adapted to change in rmarkdown 2.12 regarding math 
+* `@includeRmd` is now adapted to change in rmarkdown 2.12 regarding math
   support in `github_document()` (#1304).
 
 * `@inherit` and friends perform less aggressive link tweaking, eliminating
-  many spurious warnings. Additionally, when you do get a warning, you'll 
-  now always learn which topic it's coming from (#1135). Inherited 
-  `\ifelse{}{}{}` tags are now inserted correctly (without additional `{}`) 
+  many spurious warnings. Additionally, when you do get a warning, you'll
+  now always learn which topic it's coming from (#1135). Inherited
+  `\ifelse{}{}{}` tags are now inserted correctly (without additional `{}`)
   (#1062).
 
-* `@inherit` now supports inheriting "Notes" with `@inherit pkg::fun note` 
+* `@inherit` now supports inheriting "Notes" with `@inherit pkg::fun note`
   (@pat-s, #1218)
 
-* Automatic `@usage` now correctly wraps arguments containing syntactically 
-  significant whitespace (e.g anonymous functions) (#1281) and non-syntactic 
+* Automatic `@usage` now correctly wraps arguments containing syntactically
+  significant whitespace (e.g anonymous functions) (#1281) and non-syntactic
   values surrounded by backticks (#1257).
 
 * Markdown:
-  
+
     * Code blocks are always wrapped in `<div class="sourceCode">`
       even if the language is unknown (#1234).
 
-    * Links with markup (e.g. ``[foo `bar`][target]``) now cause an informative 
+    * Links with markup (e.g. ``[foo `bar`][target]``) now cause an informative
       warning instead of generating invalid Rd.
-      
+
     * Curly braces in links are now escaped (#1259).
 
-    * Inline R code is now powered by knitr. Where available, (knit) print 
+    * Inline R code is now powered by knitr. Where available, (knit) print
       methods are applied (#1179). This change alters outputs and brings roxygen
-      in line with console and R markdown behavior. `x <- "foo"` no longer 
-      inserts anything into the resulting documentation, but `x <- "foo"; x` 
+      in line with console and R markdown behavior. `x <- "foo"` no longer
+      inserts anything into the resulting documentation, but `x <- "foo"; x`
       will. This also means that returning a character vector will insert
       commas between components, not newlines.
 
@@ -233,7 +237,7 @@
 
 * DOIs, arXiv links, and urls in the `Description` field of the `DESCRIPTION`
   are now converted to the appropriate Rd markup (@dieghernan, #1265, #1164).
-  DOIs in the `URL` field of the `DESCRIPTION` are now converted to Rd's 
+  DOIs in the `URL` field of the `DESCRIPTION` are now converted to Rd's
   special `\doi{}` tag (@ThierryO, #1296).
 
 # roxygen2 7.1.2
@@ -287,7 +291,7 @@
 * roxygen2 now keeps using Windows (CR LF) line endings for files that
   already have CR LF line endings, and uses LF for new files (#989).
 
-## Minor improvements and bug fixes 
+## Minor improvements and bug fixes
 
 * Auto-generated package documentation can now handle author ORCID comments
   containing full url (#1040).
@@ -297,25 +301,25 @@
 * Empty annotations (alternate text) for figures added via markdown are now
   omitted. This caused issues when generating pkgdown web sites (#1051).
 
-* Roxygen metadata can now have a `packages` element, giving a character vector 
-  of package names to load. This makes it easier to use extension package that 
+* Roxygen metadata can now have a `packages` element, giving a character vector
+  of package names to load. This makes it easier to use extension package that
   provide new tags for existing roclets (#1013). See `?load_options` for
   more details.
-  
+
     ```yaml
     Roxygen: list(markdown = TRUE, packages = "roxygenlabs")
     ```
 
 * `@evalNamespace()` works again (#1022).
 
-* `@description NULL` and `@details NULL` no longer fail; instead, these tags 
-  are ignored, except for `@description NULL` in package level documentation, 
-  where it can be used to suppress the auto-generated Description section 
+* `@description NULL` and `@details NULL` no longer fail; instead, these tags
+  are ignored, except for `@description NULL` in package level documentation,
+  where it can be used to suppress the auto-generated Description section
   (#1008).
 
 * Multiple `@format` tags are now combined (#1015).
 
-* The warning for `@section` titles spanning multiple lines now includes a 
+* The warning for `@section` titles spanning multiple lines now includes a
   hint that you're missing a colon (@maelle, #994).
 
 * Can now document objects created with `delayedAssign()` by forcing
@@ -323,7 +327,7 @@
 
 # roxygen2 7.0.2
 
-* `\example{}` escaping has been improved (again!) so that special escapes 
+* `\example{}` escaping has been improved (again!) so that special escapes
   within strings are correctly escaped (#990).
 
 # roxygen2 7.0.1
@@ -332,15 +336,15 @@
   the included file will go to. It defaults to the details section (#970).
   Code chunks are now evaluated in a child of the global environment (#972).
 
-* `@inheritParams` does a better job of munging links. 
+* `@inheritParams` does a better job of munging links.
 
   Links of the form `\link[=topic]{text}` are now automatically converted to
   `\link[pkg:topic]{text}` when inherited from other packages (#979).
-  
+
   Internal `has_topic()` helper has a better implementation; this means that
   links should no longer be munged unnecessarily (#973).
 
-* `\example{}` escaping has been considerably simplified (#967), and is now 
+* `\example{}` escaping has been considerably simplified (#967), and is now
   documented in `escape_example()`.
 
 * In `\usage{}`, S3/S4 methods are no longer double-escaped (#976).
@@ -348,7 +352,7 @@
 * Markdown tables with cells that contain multiple elements (e.g. text and code)
   are now rendered correctly (#985).
 
-* Markdown code blocks containing operators and other special syntax 
+* Markdown code blocks containing operators and other special syntax
   (e.g. `function`, `if`, `+`) now converted to `\code{}` not `\verb{}` (#971).
 
 # roxygen2 7.0.0
@@ -357,45 +361,45 @@
 
 ### New tags
 
-* `@includeRmd {path.Rmd}` converts an `.Rmd`/`.md` file to `.Rd` and includes 
-  it in the manual page. This allows sharing text between vignettes, 
+* `@includeRmd {path.Rmd}` converts an `.Rmd`/`.md` file to `.Rd` and includes
+  it in the manual page. This allows sharing text between vignettes,
   `README.Rmd`, and the documentation. See `vignette("rd")` for details (#902).
 
 * `@order {n}` tag controls the order in which blocks are processed. You can
-  use it to override the usual ordering which proceeds from the top of 
-  each file to the bottom. `@order 1` will be processed before `@order 2`, 
+  use it to override the usual ordering which proceeds from the top of
+  each file to the bottom. `@order 1` will be processed before `@order 2`,
   and before any blocks that don't have an explicit order set (#863).
 
 * `@exportS3Method` tag allows you to generate `S3method()` namespace
-  directives (note the different in capitalisation) (#796). Its primary use is 
-  for "delayed" method registration, which allows you to define methods for 
+  directives (note the different in capitalisation) (#796). Its primary use is
+  for "delayed" method registration, which allows you to define methods for
   generics found in suggested packages (available in R 3.6 and greater).
   For example,
-    
+
     ```R
     #' @exportS3Method package::generic
     generic.foo <- function(x, ...) {
-    
+
     }
     ```
-    
+
     will generate
-    
+
     ```
     S3method(package::generic, foo)
     ```
-    
+
     (See [`vctrs::s3_register()`](https://vctrs.r-lib.org/reference/s3_register.html)
     you need a version that works for earlier versions of R).
-    
-    It also has a two argument form allows you generate arbitrary `S3method()` 
+
+    It also has a two argument form allows you generate arbitrary `S3method()`
     directives:
-    
+
     ```R
     #' @exportS3Method generic class
     NULL
     ```
-    
+
     ```
     S3method(generic, class)
     ```
@@ -411,45 +415,45 @@ roxygen2 can now document R6 classes (#922). See `vignette("rd")` for details.
 * Rd comments (`%`) are now automatically escaped. You will need to replace any
   existing uses of `\%` with `%` (#879).
 
-* Markdown headings are supported in tags like `@description`, `@details`, 
-  and `@return` (#907, #908). Level 1 headings create a new top-level 
+* Markdown headings are supported in tags like `@description`, `@details`,
+  and `@return` (#907, #908). Level 1 headings create a new top-level
   `\section{}`. Level 2 headings and below create nested `\subsections{}`.
 
-* Markdown tables are converted to a `\tabular{}` macro (#290). roxygen2 
+* Markdown tables are converted to a `\tabular{}` macro (#290). roxygen2
   supports the [GFM table syntax](https://github.github.com/gfm/#tables-extension-)
   which looks like this:
-  
+
     ```md
     | foo | bar |
     | --- | --- |
     | baz | bim |
     ```
 
-* Markdown code (``` `foofy` ```) is converted to to either `\code{}` or 
+* Markdown code (``` `foofy` ```) is converted to to either `\code{}` or
   `\verb{}`, depending on whether it not it parses as R code. This better
   matches the description of `\code{}` and `\verb{}` macros, solves a certain
-  class of escaping problems, and should make it easier to include arbitrary 
+  class of escaping problems, and should make it easier to include arbitrary
   "code" snippets in documentation without causing Rd failures (#654).
 
 * Markdown links can now contain formatting, e.g. `[*mean*][mean]` will now
   generate `\link[=mean]{\emph{mean}}`.
 
-* Use of unsupported markdown features (e.g. blockquotes, inline HTML, 
+* Use of unsupported markdown features (e.g. blockquotes, inline HTML,
   and horizontal rules) generates informative error messages (#804).
 
 ### Default usage
 
 * The default formatting for function usage that spans multiple lines has
-  now changed. Previously, the usage was wrapped to produce the smallest number 
+  now changed. Previously, the usage was wrapped to produce the smallest number
   of lines, e.g.:
-  
+
     ```R
-    parse_package(path = ".", env = env_package(path), 
+    parse_package(path = ".", env = env_package(path),
       registry = default_tags(), global_options = list())
     ```
-    
+
     Now it is wrapped so that each argument gets its own line (#820):
-    
+
     ```R
     parse_package(
       path = ".",
@@ -458,10 +462,10 @@ roxygen2 can now document R6 classes (#922). See `vignette("rd")` for details.
       global_options = list()
     )
     ```
-    
+
     If you prefer the old behaviour you can put the following in your
     `DESCRIPTION`:
-    
+
     ```
     Roxygen: list(old_usage = TRUE)
     ```
@@ -470,14 +474,14 @@ roxygen2 can now document R6 classes (#922). See `vignette("rd")` for details.
 
 roxygen2 now provides three strategies for loading your code (#822):
 
-* `load_pkgload()`, the default, uses [pkgload](https://github.com/r-lib/pkgload). 
-  Compared to the previous release, this now automatically recompiles your 
+* `load_pkgload()`, the default, uses [pkgload](https://github.com/r-lib/pkgload).
+  Compared to the previous release, this now automatically recompiles your
   package if needed.
 
-* `load_source()` attaches required packages and `source()`s all files in `R/`. 
-  This is a cruder simulation of package loading than pkgload (and e.g. is 
-  unreliable if you use S4 extensively), but it does not require that the 
-  package be compiled. Use if the default strategy (used in roxygen2 6.1.0 
+* `load_source()` attaches required packages and `source()`s all files in `R/`.
+  This is a cruder simulation of package loading than pkgload (and e.g. is
+  unreliable if you use S4 extensively), but it does not require that the
+  package be compiled. Use if the default strategy (used in roxygen2 6.1.0
   and above) causes you grief.
 
 * `load_installed()` assumes you have installed the package. This is best
@@ -487,26 +491,26 @@ You can override the default either by calling (e.g.) `roxygenise(load_code = "s
 
 ### Options
 
-* As well as storing roxygen options in the `Roxygen` field of the 
+* As well as storing roxygen options in the `Roxygen` field of the
   `DESCRIPTION` you can now also store them in `man/roxygen/meta.R` (#889).
   The evaluation of this file should produce a named list that maps option
-  names to values. 
-  
+  names to values.
+
 * roxygen now also looks for templates in `man/roxygen/templates` (#888).
 
 * New `rd_family_title` option: this should be a named list, and is used to
-  overrides the default "Other family: " prefix that `@family` generates. 
-  For example, to override the prefix generated by `@family foo` place 
-  `rd_family_title <- list(foo = "Custom prefix: ")` in 
+  overrides the default "Other family: " prefix that `@family` generates.
+  For example, to override the prefix generated by `@family foo` place
+  `rd_family_title <- list(foo = "Custom prefix: ")` in
   `man/roxygen/meta.R` (#830, @kevinushey).
 
 ## Breaking changes
 
-* Rd comments (`%`) are automatically escaped in markdown formatted text. 
-  This is a backward incompatible change because you will need to replace 
+* Rd comments (`%`) are automatically escaped in markdown formatted text.
+  This is a backward incompatible change because you will need to replace
   existing uses of `\%` with `%` (#879).
 
-* Using `@docType package` no longer automatically adds `-name`. Instead 
+* Using `@docType package` no longer automatically adds `-name`. Instead
   document `_PACKAGE` to get all the defaults for package documentation, or
   use `@name` to override the default file name.
 
@@ -519,34 +523,34 @@ You can override the default either by calling (e.g.) `roxygenise(load_code = "s
 
 ### Extending roxygen2
 
-The process for extending roxygen2 with new tags and new roclets has been completely overhauled, and is now documented in `vignette("extending")`. If you're one of the few people who have written a roxygen2 extension, this will break your code - but the documentation, object structure, and print methods are now so much better that I hope it's not too annoying! Because this interface is now documented, it will not change in the future without warning and a deprecation cycle. 
+The process for extending roxygen2 with new tags and new roclets has been completely overhauled, and is now documented in `vignette("extending")`. If you're one of the few people who have written a roxygen2 extension, this will break your code - but the documentation, object structure, and print methods are now so much better that I hope it's not too annoying! Because this interface is now documented, it will not change in the future without warning and a deprecation cycle.
 
 If you have previously made a new roclet, the major changes are:
 
 * The previously internal data structures used to represent blocks and tags
-  have been overhauled. They are now documented and stable. See `roxy_block()` 
+  have been overhauled. They are now documented and stable. See `roxy_block()`
   and `roxy_tag()` for details.
 
 * `roclet_tags()` is no longer used; instead define a `roxy_tag_parse()` method.
-  For example, if you create a new `@mytag` tag, it will generate a class of 
-  `roxy_tag_mytag`, and will be parsed by `roxy_tag_parse.roxy_tag_mytag()` 
-  method. The method should return a new `roxy_tag()` object with the 
+  For example, if you create a new `@mytag` tag, it will generate a class of
+  `roxy_tag_mytag`, and will be parsed by `roxy_tag_parse.roxy_tag_mytag()`
+  method. The method should return a new `roxy_tag()` object with the
   `val` field set.
-  
-    This means that the `registry` argument is no longer needed and has 
+
+    This means that the `registry` argument is no longer needed and has
     been removed.
 
-* `rd_section()` and `roxy_tag_rd()` are now exported so that you can more 
+* `rd_section()` and `roxy_tag_rd()` are now exported so that you can more
   easily extend `rd_roclet()` with your own tags that generate output in
   `.Rd` files.
 
-* `global_options` is no longer passed to all roclet methods. Instead, use 
+* `global_options` is no longer passed to all roclet methods. Instead, use
   `roxy_meta_get()` to retrieve values stored in the options (#918).
 
-* `tag_two_part()` and `tag_words()` are now simple functions, not function 
-  factories. 
+* `tag_two_part()` and `tag_words()` are now simple functions, not function
+  factories.
 
-* `tag_markdown_restricted()` has been removed because it did exactly the 
+* `tag_markdown_restricted()` has been removed because it did exactly the
    same thing as `tag_markdown()`.
 
 A big thanks goes to @mikldk for starting on the vignette and motivating me to make the extension process much more pleasant (#882).
@@ -555,45 +559,45 @@ A big thanks goes to @mikldk for starting on the vignette and motivating me to m
 
 * Empty roxygen2 lines at the start of a block are now silently removed (#710).
 
-* Whitespace is automatically trimmed off the `RoxygenNote` field when 
-  comparing the installed version of roxygen2 to the version used to 
+* Whitespace is automatically trimmed off the `RoxygenNote` field when
+  comparing the installed version of roxygen2 to the version used to
   generate the documentation (#802).
 
-* Files generated on Windows systems now retain their existing line endings, or 
+* Files generated on Windows systems now retain their existing line endings, or
   use unix-style line endings for new files (@jonthegeek, @jimhester, #840).
-  
-* roxygen2 now recognises fully qualified S4 functions like 
+
+* roxygen2 now recognises fully qualified S4 functions like
   `methods::setGeneric()`, `methods::setClass()` and `methods::setMethod()`
   (#880).
 
 * Package documentation now converts ORCIDs into a useful link (#721).
-  The package logo (if found at `man/images/logo.png`) is now scaled to 120px 
+  The package logo (if found at `man/images/logo.png`) is now scaled to 120px
   wide (@peterdesmet, #834).
 
-* Documenting an S4 method that has a `.local()` wrapper no longer fails with 
+* Documenting an S4 method that has a `.local()` wrapper no longer fails with
   an obscure error message (#847).
 
 * Functions documented in `reexports` are now sorted alphabetically by
   package (#765).
 
-* `@describeIn` can now be used with any combination of function types 
+* `@describeIn` can now be used with any combination of function types
   (#666, #848).
 
-* `@description` and `@detail` tags are automatically generated from the 
+* `@description` and `@detail` tags are automatically generated from the
   leading description block, and now have correct line numbers (#917).
 
 * `@example` and `@examples` are interwoven in the order in which they
   appear (#868).
 
-* In `@examples`, escaped `'` and `"` in strings are no longer doubly escaped 
+* In `@examples`, escaped `'` and `"` in strings are no longer doubly escaped
   (#873).
 
 * `@family` automatically adds `()` when linking to functions (#815),
   and print each link on its own line (to improve diffs).
 
-* When `@inherit`ing from external documentation, `\link{foo}` links 
-  are automatically transformed to `\link{package}{foo}` so that they work in 
-  the generated documentation (#635). `\href{}` links in external inherited are 
+* When `@inherit`ing from external documentation, `\link{foo}` links
+  are automatically transformed to `\link{package}{foo}` so that they work in
+  the generated documentation (#635). `\href{}` links in external inherited are
   now inserted correctly (without additional `{}`) (#778).
 
 * `@inherit`ing a a function with no arguments no longer throws a confusing
@@ -601,29 +605,29 @@ A big thanks goes to @mikldk for starting on the vignette and motivating me to m
 
 * `@inheritDotParams` automatically ignores arguments that can't be inherited
   through `...` because they are used by the current function (@mjskay, #885).
-  
+
 * `@inheritDotParams` includes link to function and wraps parameters
   in `\code{}` (@halldc, #842).
 
-* `@inheritDotParams` can be repeated to inherit dot docs from multiple 
+* `@inheritDotParams` can be repeated to inherit dot docs from multiple
   functions (@gustavdelius, #767).
 
 * `@inheritDotParams` avoids multiple `...` arguments (@gustavdelius, #857).
 
 * `@inheritParams` ignores leading dots when comparing argument names (#862).
 
-* `@inheritParams` warns if there are no parameters that require 
+* `@inheritParams` warns if there are no parameters that require
   documentation (#836).
 
 * `@param` containing only whitespace gives a clear warning message (#869).
 
-* Multiple `@usage` statements in a single block now generate a warning. 
+* Multiple `@usage` statements in a single block now generate a warning.
   Previously, the first was used without a warning.
 
 # roxygen2 6.1.1
 
 * Now specifically imports recent version of desc package (>= 1.2.0) to
-  fix various parsing issues (@crsh, #773, #777, #779). Multi-line DESCRIPTION 
+  fix various parsing issues (@crsh, #773, #777, #779). Multi-line DESCRIPTION
   collate directives now correctly parsed on windows (@brodieG, #790).
 
 * `roxygenise()` no longer recompiles packages containing src code (#784).

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
   (#1563, @krlmlr).
 
 * `@importFrom` works again for quoted non-syntactic names, e.g.
-  `@importFrom magrittr "%>%"` or ``@importFrom rlang `:=` ``
+  `@importFrom magrittr "%>%"` or ``@importFrom rlang `:=` `` 
   (#1570, @MichaelChirico). The unquoted form `@importFrom magrittr %>%`
   continues to work. Relatedly, `@importFrom` directives matching no known
   functions (e.g. `@importFrom utils plot pdf`) produce valid NAMESPACE files

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -225,8 +225,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   }
 
   cli::cli_abort(c(
-    "Could not resolve link to topic {.val {topic}} in the dependent
-     and base packages.",
+    "Could not resolve link to topic {.val {topic}} in the dependencies or base packages.",
     "i" = "Make sure that the name of the topic is spelled correctly.",
     "i" = "Always list the linked package as a dependency.",
     "i" = "Alternatively, you can fully qualify the link with a package name."

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -147,7 +147,7 @@ parse_link <- function(destination, contents, state) {
   s4 <- str_detect(destination, "-class$")
   noclass <- str_match(fun, "^(.*)-class$")[1,2]
 
-  if (is.na(pkg)) pkg <- resolve_link_package(obj, thispkg)
+  if (is.na(pkg)) pkg <- resolve_link_package(obj, thispkg, state = state)
   if (!is.na(pkg) && pkg == thispkg) pkg <- NA_character_
   file <- find_topic_filename(pkg, obj, state$tag)
 
@@ -185,7 +185,7 @@ parse_link <- function(destination, contents, state) {
   }
 }
 
-resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
+resolve_link_package <- function(topic, me = NULL, pkgdir = NULL, state = NULL) {
   me <- me %||% roxy_meta_get("current_package")
   # this is  from the roxygen2 tests, should not happen on a real package
   if (is.null(me) || is.na(me) || me == "") return(NA_character_)
@@ -212,10 +212,11 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
       return(pkg_has_topic)
     }
   } else {
-    cli::cli_warn(c(
-      "Topic {.val {topic}} is available in multiple packages: {.pkg {pkg_has_topic}}.",
+    warn_roxy_tag(state$tag, c(
+      "Topic {.val {topic}} is available in multiple packages: {.pkg {pkg_has_topic}}",
       i = "Qualify topic explicitly with a package name when linking to it."
     ))
+    return(NA_character_)
   }
 
   # try base packages as well, take the first hit,
@@ -224,15 +225,17 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
     if (has_topic(topic, bp)) return(NA_character_)
   }
 
-  cli::cli_warn(c(
-    "Could not resolve link to topic {.val {topic}} in the dependencies or base packages.",
+  warn_roxy_tag(state$tag, c(
+    "Could not resolve link to topic {.val {topic}} in the dependencies or base packages",
     "i" = paste(
-      "If you haven'r documented {.val {topic}} yet, or just changed its name, this is normal.",
+      "If you haven't documented {.val {topic}} yet, or just changed its name, this is normal.",
       "Once {.val {topic}} is documented, this warning goes away."),
     "i" = "Make sure that the name of the topic is spelled correctly.",
     "i" = "Always list the linked package as a dependency.",
     "i" = "Alternatively, you can fully qualify the link with a package name."
   ))
+
+  NA_character_
 }
 
 # this is mostly from downlit

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -203,13 +203,15 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   })
   pkg_has_topic <- unique(pkg_has_topic)
   base <- base_packages()
-  if (length(pkg_has_topic) == 1) {
+  if (length(pkg_has_topic) == 0) {
+    # fall through to check base packages as well
+  } else if (length(pkg_has_topic) == 1) {
     if (pkg_has_topic %in% base) {
       return(NA_character_)
     } else {
       return(pkg_has_topic)
     }
-  } else if (length(pkg_has_topic) > 1) {
+  } else {
     cli::cli_abort(c(
       "Topic {.val {topic}} is available in multiple packages: {.pkg {pkg_has_topic}}.",
       i = "Qualify topic explicitly with a package name when linking to it."

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -195,7 +195,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
 
   # try packages in depends, imports, suggests first, error on name clashes
   pkgdir <- pkgdir %||% roxy_meta_get("current_package_dir")
-  deps <- desc::desc_get_deps(pkgdir)
+  deps <- mddata[["deps"]] <- mddata[["deps"]] %||% desc::desc_get_deps(pkgdir)
   deps <- deps[deps$package != "R", ]
   deps <- deps[deps$type %in% c("Depends", "Imports", "Suggests"), ]
   pkgs <- deps$package

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -14,7 +14,7 @@
 #' [fun()]            fun()       T   \\link[=fun]{fun()} or
 #'                                    \\link[pkg:file]{pkg::fun()}
 #' [obj]              obj         F   \\link{obj} or
-#'                                    \\link[pkg:obj]{pkg::obj}
+#'                                    \\link[pkg:file]{pkg::obj}
 #' [pkg::fun()]       pkg::fun()  T   \\link[pkg:file]{pkg::fun()}
 #' [pkg::obj]         pkg::obj    F   \\link[pkg:file]{pkg::obj}
 #' [text][fun()]      text        F   \\link[=fun]{text} or

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -187,8 +187,8 @@ parse_link <- function(destination, contents, state) {
 
 resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   me <- me %||% roxy_meta_get("current_package")
-  # this is probably from the roxygen2 tests
-  if (me == "") return(NA_character_)
+  # this is  from the roxygen2 tests, should not happen on a real package
+  if (is.null(me) || is.na(me) || me == "") return(NA_character_)
 
   # if it is in the current package, then no need for package name, right?
   if (has_topic(topic, me)) return(NA_character_)
@@ -201,8 +201,13 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   pkgs <- deps$package
 
   pkg_has_topic <- pkgs[map_lgl(pkgs, has_topic, topic = topic)]
+  base <- base_packages()
   if (length(pkg_has_topic) == 1) {
-    return(pkg_has_topic)
+    if (pkg_has_topic %in% base) {
+      return(NA_character_)
+    } else {
+      return(pkg_has_topic)
+    }
   } else if (length(pkg_has_topic) > 1) {
     cli::cli_abort(c(
       "Topic {.val {topic}} is available in multiple packages: {.pkg {pkgs}}.",
@@ -212,9 +217,8 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
 
   # try base packages as well, take the first hit,
   # there should not be any name clashes, anyway
-  base <- base_packages()
   for (bp in base) {
-    if (has_topic(topic, bp)) return(bp)
+    if (has_topic(topic, bp)) return(NA_character_)
   }
 
   cli::cli_abort(c(

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -212,7 +212,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
       return(pkg_has_topic)
     }
   } else {
-    cli::cli_abort(c(
+    cli::cli_warn(c(
       "Topic {.val {topic}} is available in multiple packages: {.pkg {pkg_has_topic}}.",
       i = "Qualify topic explicitly with a package name when linking to it."
     ))
@@ -224,8 +224,11 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
     if (has_topic(topic, bp)) return(NA_character_)
   }
 
-  cli::cli_abort(c(
+  cli::cli_warn(c(
     "Could not resolve link to topic {.val {topic}} in the dependencies or base packages.",
+    "i" = paste(
+      "If you haven'r documented {.val {topic}} yet, or just changed its name, this is normal.",
+      "Once {.val {topic}} is documented, this warning goes away."),
     "i" = "Make sure that the name of the topic is spelled correctly.",
     "i" = "Always list the linked package as a dependency.",
     "i" = "Alternatively, you can fully qualify the link with a package name."

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -194,11 +194,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   if (has_topic(topic, me)) return(NA_character_)
 
   # try packages in depends, imports, suggests first, error on name clashes
-  pkgdir <- pkgdir %||% roxy_meta_get("current_package_dir")
-  deps <- mddata[["deps"]] <- mddata[["deps"]] %||% desc::desc_get_deps(pkgdir)
-  deps <- deps[deps$package != "R", ]
-  deps <- deps[deps$type %in% c("Depends", "Imports", "Suggests"), ]
-  pkgs <- deps$package
+  pkgs <- local_pkg_deps(pkgdir)
 
   pkg_has_topic <- pkgs[map_lgl(pkgs, has_topic, topic = topic)]
   pkg_has_topic <- map_chr(pkg_has_topic, function(p) {

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -12,15 +12,15 @@
 #' MARKDOWN           LINK TEXT  CODE RD
 #' --------           ---------  ---- --
 #' [fun()]            fun()       T   \\link[=fun]{fun()} or
-#'                                    \\link[pkg::file]{fun()}
+#'                                    \\link[pkg:file]{fun()}
 #' [obj]              obj         F   \\link{obj} or
-#'                                    \\link[pkg::obj]{obj}
+#'                                    \\link[pkg:obj]{obj}
 #' [pkg::fun()]       pkg::fun()  T   \\link[pkg:file]{pkg::fun()}
 #' [pkg::obj]         pkg::obj    F   \\link[pkg:file]{pkg::obj}
 #' [text][fun()]      text        F   \\link[=fun]{text} or
 #'                                    \\link[pkg:file]{text}
 #' [text][obj]        text        F   \\link[=obj]{text} or
-#'                                    \\link[pkg::file]{text}
+#'                                    \\link[pkg:file]{text}
 #' [text][pkg::fun()] text        F   \\link[pkg:file]{text}
 #' [text][pkg::obj]   text        F   \\link[pkg:file]{text}
 #' [s4-class]         s4          F   \\linkS4class{s4} or
@@ -197,7 +197,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   pkgdir <- pkgdir %||% roxy_meta_get("current_package_dir")
   deps <- desc::desc_get_deps(pkgdir)
   deps <- deps[deps$package != "R", ]
-  deps <- deps[deps$type %in% c("Depeneds", "Imports", "Suggests"), ]
+  deps <- deps[deps$type %in% c("Depends", "Imports", "Suggests"), ]
   pkgs <- deps$package
 
   pkg_has_topic <- pkgs[map_lgl(pkgs, has_topic, topic = topic)]

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -201,6 +201,11 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   pkgs <- deps$package
 
   pkg_has_topic <- pkgs[map_lgl(pkgs, has_topic, topic = topic)]
+  pkg_has_topic <- map_chr(pkg_has_topic, function(p) {
+    p0 <- find_reexport_source(topic, p)
+    if (is.na(p0)) p else p0
+  })
+  pkg_has_topic <- unique(pkg_has_topic)
   base <- base_packages()
   if (length(pkg_has_topic) == 1) {
     if (pkg_has_topic %in% base) {
@@ -210,8 +215,8 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
     }
   } else if (length(pkg_has_topic) > 1) {
     cli::cli_abort(c(
-      "Topic {.val {topic}} is available in multiple packages: {.pkg {pkgs}}.",
-      i = "Qualify topic explicitly with a package name."
+      "Topic {.val {topic}} is available in multiple packages: {.pkg {pkg_has_topic}}.",
+      i = "Qualify topic explicitly with a package name when linking to it."
     ))
   }
 
@@ -230,6 +235,7 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
   ))
 }
 
+# this is mostly from downlit
 is_exported <- function(name, package) {
   name %in% getNamespaceExports(ns_env(package))
 }
@@ -240,6 +246,37 @@ is_reexported <- function(name, package) {
   }
   is_imported <- env_has(ns_imports_env(package), name)
   is_imported && is_exported(name, package)
+}
+
+find_reexport_source <- function(topic, package) {
+  ns <- ns_env(package)
+  if (!env_has(ns, topic, inherit = TRUE)) {
+    return(NA_character_)
+  }
+
+  obj <- env_get(ns, topic, inherit = TRUE)
+  if (is.primitive(obj)) {
+    # primitive functions all live in base
+    "base"
+  } else if (is.function(obj)) {
+    ## For functions, we can just take their environment.
+    ns_env_name(get_env(obj))
+  } else {
+    ## For other objects, we need to check the import env of the package,
+    ## to see where 'topic' is coming from. The import env has redundant
+    ## information. It seems that we just need to find a named list
+    ## entry that contains `topic`.
+    imp <- getNamespaceImports(ns)
+    imp <- imp[names(imp) != ""]
+    wpkgs <- vapply(imp, `%in%`, x = topic, FUN.VALUE = logical(1))
+
+    if (!any(wpkgs)) {
+      return(NA_character_)
+    }
+    pkgs <- names(wpkgs)[wpkgs]
+    # Take the last match, in case imports have name clashes.
+    pkgs[[length(pkgs)]]
+  }
 }
 
 #' Dummy page to test roxygen's markdown formatting

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -28,7 +28,7 @@
 #' [pkg::s4-class]    pkg::s4     F   \\link[pkg:file]{pkg::s4}
 #' ```
 #'
-#' For the ones that have two RD variants the first version is used for
+#' For the links with two RD variants the first version is used for
 #' within-package links, and the second version is used for cross-package
 #' links.
 #'

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -12,9 +12,9 @@
 #' MARKDOWN           LINK TEXT  CODE RD
 #' --------           ---------  ---- --
 #' [fun()]            fun()       T   \\link[=fun]{fun()} or
-#'                                    \\link[pkg:file]{fun()}
+#'                                    \\link[pkg:file]{pkg::fun()}
 #' [obj]              obj         F   \\link{obj} or
-#'                                    \\link[pkg:obj]{obj}
+#'                                    \\link[pkg:obj]{pkg::obj}
 #' [pkg::fun()]       pkg::fun()  T   \\link[pkg:file]{pkg::fun()}
 #' [pkg::obj]         pkg::obj    F   \\link[pkg:file]{pkg::obj}
 #' [text][fun()]      text        F   \\link[=fun]{text} or
@@ -224,6 +224,18 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL) {
     "i" = "Always list the linked package as a dependency.",
     "i" = "Alternatively, you can fully qualify the link with a package name."
   ))
+}
+
+is_exported <- function(name, package) {
+  name %in% getNamespaceExports(ns_env(package))
+}
+
+is_reexported <- function(name, package) {
+  if (package == "base") {
+    return(FALSE)
+  }
+  is_imported <- env_has(ns_imports_env(package), name)
+  is_imported && is_exported(name, package)
 }
 
 #' Dummy page to test roxygen's markdown formatting

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -17,6 +17,8 @@ markdown <- function(text, tag = NULL, sections = FALSE) {
   )
 }
 
+mddata <- new.env(parent = emptyenv())
+
 #' Expand the embedded inline code
 #'
 #' @details
@@ -68,6 +70,7 @@ markdown <- function(text, tag = NULL, sections = FALSE) {
 #' @keywords internal
 
 markdown_pass1 <- function(text) {
+  rm(list = ls(envir = mddata), envir = mddata)
   text <- paste(text, collapse = "\n")
   mdxml <- xml_ns_strip(md_to_mdxml(text, sourcepos = TRUE))
   code_nodes <- xml_find_all(mdxml, ".//code | .//code_block")

--- a/R/options.R
+++ b/R/options.R
@@ -66,6 +66,7 @@ load_options <- function(base_path = ".") {
     markdown = FALSE,
     r6 = TRUE,
     current_package = NA_character_,
+    current_package_dir = NA_character_,
     rd_family_title = list(),
     knitr_chunk_options = NULL,
     restrict_image_formats = TRUE
@@ -94,6 +95,7 @@ load_options_description <- function(base_path = ".") {
   }
 
   opts$current_package <- dcf[[1, 2]]
+  opts$current_package_dir <- normalizePath(base_path)
   opts
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,3 +193,18 @@ base_packages <- function() {
     )
   }
 }
+
+# Note that this caches the result regardless of
+# pkgdir! pkgdir is mainly for testing, in which case you
+# need to clear the cache manually.
+
+local_pkg_deps <- function(pkgdir = NULL) {
+  if (!is.null(mddata[["deps"]])) {
+    return(mddata[["deps"]])
+  }
+  pkgdir <- pkgdir %||% roxy_meta_get("current_package_dir")
+  deps <- desc::desc_get_deps(pkgdir)
+  deps <- deps[deps$package != "R", ]
+  deps <- deps[deps$type %in% c("Depends", "Imports", "Suggests"), ]
+  deps$package
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -185,7 +185,7 @@ strip_quotes <- function(x) str_replace(x, "^(`|'|\")(.*)\\1$", "\\2")
 
 base_packages <- function() {
   if (getRversion() >= "4.4.0") {
-    tools::standard_package_names()[["base"]]
+    asNamespace("tools")$standard_package_names()[["base"]]
   } else {
     c("base", "compiler", "datasets",
       "graphics", "grDevices", "grid", "methods", "parallel",

--- a/R/utils.R
+++ b/R/utils.R
@@ -182,3 +182,14 @@ auto_quote <- function(x) {
 is_syntactic <- function(x) make.names(x) == x
 has_quotes <- function(x) str_detect(x, "^(`|'|\").*\\1$")
 strip_quotes <- function(x) str_replace(x, "^(`|'|\")(.*)\\1$", "\\2")
+
+base_packages <- function() {
+  if (getRversion() >= "4.4.0") {
+    tools::standard_package_names()[["base"]]
+  } else {
+    c("base", "compiler", "datasets",
+      "graphics", "grDevices", "grid", "methods", "parallel",
+      "splines", "stats", "stats4", "tcltk", "tools", "utils"
+    )
+  }
+}

--- a/man/is_s3_generic.Rd
+++ b/man/is_s3_generic.Rd
@@ -17,7 +17,7 @@ is_s3_method(name, env = parent.frame())
 \description{
 \code{is_s3_generic} compares name to \code{.knownS3Generics} and
 \code{.S3PrimitiveGenerics}, then looks at the function body to see if it
-calls \code{\link[base:UseMethod]{base::UseMethod()}}.
+calls \code{\link[=UseMethod]{UseMethod()}}.
 
 \code{is_s3_method} builds names of all possible generics for that function
 and then checks if any of them actually is a generic.

--- a/man/is_s3_generic.Rd
+++ b/man/is_s3_generic.Rd
@@ -17,7 +17,7 @@ is_s3_method(name, env = parent.frame())
 \description{
 \code{is_s3_generic} compares name to \code{.knownS3Generics} and
 \code{.S3PrimitiveGenerics}, then looks at the function body to see if it
-calls \code{\link[=UseMethod]{UseMethod()}}.
+calls \code{\link[base:UseMethod]{base::UseMethod()}}.
 
 \code{is_s3_method} builds names of all possible generics for that function
 and then checks if any of them actually is a generic.

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -58,7 +58,7 @@
         "testMdLinks2"))
     Condition
       Error in `resolve_link_package()`:
-      ! Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependent and base packages.
+      ! Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependencies or base packages.
       i Make sure that the name of the topic is spelled correctly.
       i Always list the linked package as a dependency.
       i Alternatively, you can fully qualify the link with a package name.

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -57,8 +57,9 @@
       resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path(
         "testMdLinks2"))
     Condition
-      Error in `resolve_link_package()`:
-      ! Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependencies or base packages.
+      Warning:
+      Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependencies or base packages.
+      i If you haven'r documented "aa3bc042880aa3b64fef1a9" yet, or just changed its name, this is normal. Once "aa3bc042880aa3b64fef1a9" is documented, this warning goes away.
       i Make sure that the name of the topic is spelled correctly.
       i Always list the linked package as a dependency.
       i Alternatively, you can fully qualify the link with a package name.
@@ -68,7 +69,13 @@
     Code
       resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
     Condition
-      Error in `resolve_link_package()`:
-      ! Topic "pkg_env" is available in multiple packages: pkgload and rlang.
+      Warning:
+      Topic "pkg_env" is available in multiple packages: pkgload and rlang.
       i Qualify topic explicitly with a package name when linking to it.
+      Warning:
+      Could not resolve link to topic "pkg_env" in the dependencies or base packages.
+      i If you haven'r documented "pkg_env" yet, or just changed its name, this is normal. Once "pkg_env" is documented, this warning goes away.
+      i Make sure that the name of the topic is spelled correctly.
+      i Always list the linked package as a dependency.
+      i Alternatively, you can fully qualify the link with a package name.
 

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -36,3 +36,29 @@
     Message
       x <text>:4: @description refers to unavailable topic stringr::bar111.
 
+# resolve_link_package
+
+    Code
+      resolve_link_package("roxygenize", "roxygen2", ".")
+    Output
+      [1] NA
+    Code
+      resolve_link_package("UseMethod", "roxygen2", ".")
+    Output
+      [1] "base"
+    Code
+      resolve_link_package("cli_abort", "roxygen2", ".")
+    Output
+      [1] "cli"
+
+---
+
+    Code
+      resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", ".")
+    Condition
+      Error in `resolve_link_package()`:
+      ! Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependent and base packages.
+      i Make sure that the name of the topic is spelled correctly.
+      i Always list the linked package as a dependency.
+      i Alternatively, you can fully qualify the link with a package name.
+

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -45,7 +45,7 @@
     Code
       resolve_link_package("UseMethod", "roxygen2", ".")
     Output
-      [1] "base"
+      [1] NA
     Code
       resolve_link_package("cli_abort", "roxygen2", ".")
     Output

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -55,27 +55,24 @@
 
     Code
       resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path(
-        "testMdLinks2"))
-    Condition
-      Warning:
-      Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependencies or base packages.
-      i If you haven'r documented "aa3bc042880aa3b64fef1a9" yet, or just changed its name, this is normal. Once "aa3bc042880aa3b64fef1a9" is documented, this warning goes away.
+        "testMdLinks2"), list(tag = tag))
+    Message
+      x foo.R:10: @title (automatically generated) Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependencies or base packages.
+      i If you haven't documented "aa3bc042880aa3b64fef1a9" yet, or just changed its name, this is normal. Once "aa3bc042880aa3b64fef1a9" is documented, this warning goes away.
       i Make sure that the name of the topic is spelled correctly.
       i Always list the linked package as a dependency.
       i Alternatively, you can fully qualify the link with a package name.
+    Output
+      [1] NA
 
 # resolve_link_package name clash
 
     Code
-      resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
-    Condition
-      Warning:
-      Topic "pkg_env" is available in multiple packages: pkgload and rlang.
+      resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"), list(
+        tag = tag))
+    Message
+      x foo.R:10: @title (automatically generated) Topic "pkg_env" is available in multiple packages: pkgload and rlang.
       i Qualify topic explicitly with a package name when linking to it.
-      Warning:
-      Could not resolve link to topic "pkg_env" in the dependencies or base packages.
-      i If you haven'r documented "pkg_env" yet, or just changed its name, this is normal. Once "pkg_env" is documented, this warning goes away.
-      i Make sure that the name of the topic is spelled correctly.
-      i Always list the linked package as a dependency.
-      i Alternatively, you can fully qualify the link with a package name.
+    Output
+      [1] NA
 

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -39,26 +39,36 @@
 # resolve_link_package
 
     Code
-      resolve_link_package("roxygenize", "roxygen2", ".")
+      resolve_link_package("roxygenize", "roxygen2", test_path("testMdLinks2"))
     Output
       [1] NA
     Code
-      resolve_link_package("UseMethod", "roxygen2", ".")
+      resolve_link_package("UseMethod", "roxygen2", test_path("testMdLinks2"))
     Output
       [1] NA
     Code
-      resolve_link_package("cli_abort", "roxygen2", ".")
+      resolve_link_package("cli_abort", "roxygen2", test_path("testMdLinks2"))
     Output
       [1] "cli"
 
 ---
 
     Code
-      resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", ".")
+      resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path(
+        "testMdLinks2"))
     Condition
       Error in `resolve_link_package()`:
       ! Could not resolve link to topic "aa3bc042880aa3b64fef1a9" in the dependent and base packages.
       i Make sure that the name of the topic is spelled correctly.
       i Always list the linked package as a dependency.
       i Alternatively, you can fully qualify the link with a package name.
+
+# resolve_link_package name clash
+
+    Code
+      resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
+    Condition
+      Error in `resolve_link_package()`:
+      ! Topic "pkg_env" is available in multiple packages: pkgload and rlang.
+      i Qualify topic explicitly with a package name when linking to it.
 

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -477,3 +477,14 @@ test_that("percents are escaped in link targets", {
     foo <- function() {}")[[1]]
   expect_equivalent_rd(out1, out2)
 })
+
+test_that("resolve_link_package", {
+  expect_snapshot({
+    resolve_link_package("roxygenize", "roxygen2", ".")
+    resolve_link_package("UseMethod", "roxygen2", ".")
+    resolve_link_package("cli_abort", "roxygen2", ".")
+  })
+  expect_snapshot(error = TRUE, {
+    resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", ".")
+  })
+})

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -485,8 +485,10 @@ test_that("resolve_link_package", {
     resolve_link_package("UseMethod", "roxygen2", test_path("testMdLinks2"))
     resolve_link_package("cli_abort", "roxygen2", test_path("testMdLinks2"))
   })
+
+  tag <- roxy_tag("title", NULL, NULL, file = "foo.R", line = 10)
   expect_snapshot({
-    resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path("testMdLinks2"))
+    resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path("testMdLinks2"), list(tag = tag))
   })
   # re-exported topics are identified
   rm(list = ls(envir = mddata), envir = mddata)
@@ -499,8 +501,9 @@ test_that("resolve_link_package", {
 test_that("resolve_link_package name clash", {
   # skip in case pkgload/rlang changes this
   skip_on_cran()
+  tag <- roxy_tag("title", NULL, NULL, file = "foo.R", line = 10)
   expect_snapshot({
-    resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
+    resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"), list(tag = tag))
   })
 })
 

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -479,12 +479,36 @@ test_that("percents are escaped in link targets", {
 })
 
 test_that("resolve_link_package", {
+  rm(list = ls(envir = mddata), envir = mddata)
   expect_snapshot({
-    resolve_link_package("roxygenize", "roxygen2", ".")
-    resolve_link_package("UseMethod", "roxygen2", ".")
-    resolve_link_package("cli_abort", "roxygen2", ".")
+    resolve_link_package("roxygenize", "roxygen2", test_path("testMdLinks2"))
+    resolve_link_package("UseMethod", "roxygen2", test_path("testMdLinks2"))
+    resolve_link_package("cli_abort", "roxygen2", test_path("testMdLinks2"))
   })
   expect_snapshot(error = TRUE, {
-    resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", ".")
+    resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path("testMdLinks2"))
   })
+  # re-exported topics are identified
+  rm(list = ls(envir = mddata), envir = mddata)
+  expect_equal(
+    resolve_link_package("process", "testthat", test_path("testMdLinks")),
+    "processx"
+  )
+})
+
+test_that("resolve_link_package name clash", {
+  # skip in case pkgload/rlang changes this
+  skip_on_cran()
+  expect_snapshot(error = TRUE, {
+    resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
+  })
+})
+
+test_that("is_reexported", {
+  expect_false(is_reexported("process", "processx"))
+  expect_true(is_reexported("process", "callr"))
+})
+
+test_that("find_reexport_source", {
+  expect_equal(find_reexport_source("process", "callr"), "processx")
 })

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -485,7 +485,7 @@ test_that("resolve_link_package", {
     resolve_link_package("UseMethod", "roxygen2", test_path("testMdLinks2"))
     resolve_link_package("cli_abort", "roxygen2", test_path("testMdLinks2"))
   })
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     resolve_link_package("aa3bc042880aa3b64fef1a9", "roxygen2", test_path("testMdLinks2"))
   })
   # re-exported topics are identified
@@ -499,7 +499,7 @@ test_that("resolve_link_package", {
 test_that("resolve_link_package name clash", {
   # skip in case pkgload/rlang changes this
   skip_on_cran()
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     resolve_link_package("pkg_env", "roxygen2", test_path("testMdLinks2"))
   })
 })

--- a/tests/testthat/test-rd-describe-in.R
+++ b/tests/testthat/test-rd-describe-in.R
@@ -263,4 +263,3 @@ test_that("complains about bad usage", {
   "
   expect_snapshot(. <- roc_proc_text(rd_roclet(), block))
 })
-

--- a/tests/testthat/test-rd-include-rmd.R
+++ b/tests/testthat/test-rd-include-rmd.R
@@ -1,5 +1,8 @@
 skip_if_not_installed("rmarkdown")
 
+# clear some state
+roxy_meta_clear()
+
 test_that("invalid syntax gives useful warning", {
   block <- "
     #' @includeRmd

--- a/tests/testthat/testMdLinks/DESCRIPTION
+++ b/tests/testthat/testMdLinks/DESCRIPTION
@@ -1,0 +1,58 @@
+Package: testthat
+Title: Unit Testing for R
+Version: 3.2.1.9000
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre")),
+    person("Posit Software, PBC", role = c("cph", "fnd")),
+    person("R Core team", role = "ctb",
+           comment = "Implementation of utils::recover()")
+  )
+Description: Software testing is important, but, in part because it is
+    frustrating and boring, many of us avoid it. 'testthat' is a testing
+    framework for R that is easy to learn and use, and integrates with
+    your existing 'workflow'.
+License: MIT + file LICENSE
+URL: https://testthat.r-lib.org, https://github.com/r-lib/testthat
+BugReports: https://github.com/r-lib/testthat/issues
+Depends: 
+    R (>= 3.6.0)
+Imports:
+    brio (>= 1.1.3),
+    callr (>= 3.7.3),
+    cli (>= 3.6.1),
+    desc (>= 1.4.2),
+    digest (>= 0.6.33),
+    evaluate (>= 0.21),
+    jsonlite (>= 1.8.7),
+    lifecycle (>= 1.0.3),
+    magrittr (>= 2.0.3),
+    methods,
+    pkgload (>= 1.3.2.1),
+    praise (>= 1.0.0),
+    processx (>= 3.8.2),
+    ps (>= 1.7.5),
+    R6 (>= 2.5.1),
+    rlang (>= 1.1.1),
+    utils,
+    waldo (>= 0.5.1),
+    withr (>= 2.5.0)
+Suggests: 
+    covr,
+    curl (>= 0.9.5),
+    diffviewer (>= 0.1.0),
+    knitr,
+    rmarkdown,
+    rstudioapi,
+    shiny,
+    usethis,
+    vctrs (>= 0.1.0),
+    xml2
+VignetteBuilder: 
+    knitr
+Config/Needs/website: tidyverse/tidytemplate
+Config/testthat/edition: 3
+Config/testthat/parallel: true
+Config/testthat/start-first: watcher, parallel*
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE, r6 = FALSE)
+RoxygenNote: 7.2.3

--- a/tests/testthat/testMdLinks2/DESCRIPTION
+++ b/tests/testthat/testMdLinks2/DESCRIPTION
@@ -1,0 +1,56 @@
+Package: roxygen2
+Title: In-Line Documentation for R
+Version: 7.3.2.9000
+Authors@R: c(
+    person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre", "cph"),
+           comment = c(ORCID = "0000-0003-4757-117X")),
+    person("Peter", "Danenberg", , "pcd@roxygen.org", role = c("aut", "cph")),
+    person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = "aut"),
+    person("Manuel", "Eugster", role = c("aut", "cph")),
+    person("Posit Software, PBC", role = c("cph", "fnd"))
+  )
+Description: Generate your Rd documentation, 'NAMESPACE' file, and
+    collation field using specially formatted comments. Writing
+    documentation in-line with code makes it easier to keep your
+    documentation up-to-date as your requirements change. 'roxygen2' is
+    inspired by the 'Doxygen' system for C++.
+License: MIT + file LICENSE
+URL: https://roxygen2.r-lib.org/, https://github.com/r-lib/roxygen2
+BugReports: https://github.com/r-lib/roxygen2/issues
+Depends: 
+    R (>= 3.6)
+Imports: 
+    brew,
+    cli (>= 3.3.0),
+    commonmark,
+    desc (>= 1.2.0),
+    knitr,
+    methods,
+    pkgload (>= 1.0.2),
+    purrr (>= 1.0.0),
+    R6 (>= 2.1.2),
+    rlang (>= 1.0.6),
+    stringi,
+    stringr (>= 1.0.0),
+    utils,
+    withr,
+    xml2
+Suggests: 
+    covr,
+    R.methodsS3,
+    R.oo,
+    rmarkdown (>= 2.16),
+    testthat (>= 3.1.2),
+    yaml
+LinkingTo: 
+    cpp11
+VignetteBuilder: 
+    knitr
+Config/Needs/development: testthat
+Config/Needs/website: tidyverse/tidytemplate
+Config/testthat/edition: 3
+Config/testthat/parallel: TRUE
+Encoding: UTF-8
+Language: en-GB
+Roxygen: list(markdown = TRUE, load = "installed")
+RoxygenNote: 7.3.2.9000

--- a/tests/testthat/testRawNamespace/DESCRIPTION
+++ b/tests/testthat/testRawNamespace/DESCRIPTION
@@ -6,4 +6,4 @@ Author: Hadley <hadley@rstudio.com>
 Maintainer: Hadley <hadley@rstudio.com>
 Encoding: UTF-8
 Version: 0.1
-RoxygenNote: 7.3.0.9000
+RoxygenNote: 7.3.2.9000

--- a/vignettes/rd-formatting.Rmd
+++ b/vignettes/rd-formatting.Rmd
@@ -209,6 +209,16 @@ There are two basic forms:
 -   `[topic]`: The link text is automatically generated from the topic.
 -   `[text][topic]`: You supply the link text.
 
+If `topic` is not a help topic within the package you are documenting,
+but it is in one of its dependent packages, roxygen2 will try to find
+which package it is coming from to generate a fully qualified link. Fully
+qualified links are required by R 4.5.0 and later.
+
+If multiple dependent packages document `topic`, then roxygen2 will stop
+with an error. Re-exported functions and objects do not generate an error,
+however, but roxygen2 will link to the package that originally defines the
+re-exported object.
+
 ### Default link text
 
 First we explore the simplest form: `[ref]`.
@@ -362,4 +372,3 @@ The commonmark parser does not require an empty line before lists, and this migh
 #' You can see more about this topic in the book cited below, on page
 #' 42. Clearly, the numbered list that starts here is not intentional.
 ```
-


### PR DESCRIPTION
- [x] ~~Anchor links to base packages as well.~~
- [x] [Do **not** anchor base packages.](https://github.com/r-lib/roxygen2/issues/1612#issuecomment-2218740209)
- [x] Tests.
- [x] News.
- [x] Docs.
- [x] Cache dependency info.
- [x] Resolve re-exported functions.

Closes #1612.