### PR TITLE
fix: Support multiline `@examplesIf` again

### DIFF
--- a/R/rd-examples.R
+++ b/R/rd-examples.R
@@ -15,10 +15,12 @@ roxy_tag_parse.roxy_tag_examplesIf <- function(x) {
   )
 
   x$raw <- paste(
-    paste0("\\dontshow{if (", condition, ") withAutoprint(\\{ # examplesIf}"),
-    lines[-1],
-    "\\dontshow{\\}) # examplesIf}",
-    sep = "\n"
+    c(
+      paste0("\\dontshow{if (", condition, ") withAutoprint(\\{ # examplesIf}"),
+      lines[-1],
+      "\\dontshow{\\}) # examplesIf}"
+    ),
+    collapse = "\n"
   )
 
   tag_examples(x)

--- a/tests/testthat/_snaps/rd-examples.md
+++ b/tests/testthat/_snaps/rd-examples.md
@@ -29,6 +29,7 @@
     \dontshow{\}) # examplesIf}
     \dontshow{if (foobar()) withAutoprint(\{ # examplesIf}
     and-this
+    and-that
     \dontshow{\}) # examplesIf}
     } 
 

--- a/tests/testthat/test-rd-examples.R
+++ b/tests/testthat/test-rd-examples.R
@@ -79,6 +79,7 @@ test_that("@examplesIf", {
     #' maybe-run-this-code
     #' @examplesIf foobar()
     #' and-this
+    #' and-that
     NULL")[[1]]
 
   expect_snapshot_output(out$get_section("examples"))


### PR DESCRIPTION
Fallout from https://github.com/r-lib/roxygen2/pull/1582.

Symptoms: https://github.com/r-prof/profile/actions/runs/10209333641/job/28247195516#step:11:73

```
Error: Error in map(seq_along(tokens), function(i) { : ℹ In index: 7.
Caused by error in `map()` at roxygen2/R/block.R:216:3:
ℹ In index: 5.
Caused by error in `if (str_trim(x$raw) == "") ...`:
! the condition has length > 1
```

CC @MichaelChirico.