### PR TITLE
Use local_package_copy() for test writing to test path

### DIFF
--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -306,7 +306,7 @@ test_that("rawNamespace inserted unchanged", {
 })
 
 test_that("rawNamespace does not break idempotency", {
-  test_pkg <- test_path("testRawNamespace")
+  test_pkg <- local_package_copy(test_path("testRawNamespace"))
   NAMESPACE <- file.path(test_pkg, "NAMESPACE")
 
   lines_orig <- read_lines(NAMESPACE)


### PR DESCRIPTION
Our test environment does not have write permissions, causing this to fail.

Usually I ignore these issues, but in this case {roxygen2} already has a relevant helper, it's just not being used in this case (probably because the test is of idempotency --> the test package is not expected to change at all).

I am proposing the change here for consistency sake, but it's not strongly motivated besides our use case -- feel free to close :)