### PR TITLE
feat: Support markup in link text for R >= 4.5.0

### DIFF
--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -1,4 +1,4 @@
-#' Add link reference definitions for functions to a markdown text.
+#' Add link reference definitions for functions to a Markdown text.
 #'
 #' We find the `[text][ref]` and the `[ref]` forms. There must be no
 #' spaces between the closing and opening bracket in the `[text][ref]`
@@ -43,7 +43,7 @@
 #' In the link references, we need to URL encode the reference,
 #' otherwise commonmark does not use it (see issue #518).
 #'
-#' @param text Input markdown text.
+#' @param text Input Markdown text.
 #' @return The input text and all dummy reference link definitions
 #'   appended.
 #'
@@ -58,7 +58,7 @@ get_md_linkrefs <- function(text) {
         (?<=[^\\]\\\\]|^)       # must not be preceded by ] or \
         \\[([^\\]\\[]+)\\]      # match anything inside of []
         (?:\\[([^\\]\\[]+)\\])? # match optional second pair of []
-        (?=[^\\[{]|$)            # must not be followed by [ or {
+        (?=[^\\[{]|$)           # must not be followed by [ or {
       "
     )
   )[[1]]
@@ -83,11 +83,11 @@ add_linkrefs_to_md <- function(text) {
   paste0(text, "\n\n", ref_text, "\n")
 }
 
-#' Parse a MarkDown link, to see if we should create an Rd link
+#' Parse a Markdown link, to see if we should create an Rd link
 #'
 #' See the table above.
 #'
-#' @param destination string constant, the "url" of the link
+#' @param destination String constant, the "URL" of the link.
 #' @param contents An XML node, containing the contents of the link.
 #'
 #' @noRd
@@ -95,7 +95,7 @@ add_linkrefs_to_md <- function(text) {
 parse_link <- function(destination, contents, state) {
 
   ## Not a [] or [][] type link, remove prefix if it is
-  if (! grepl("^R:", destination)) return(NULL)
+  if (!grepl("^R:", destination)) return(NULL)
   destination <- sub("^R:", "", URLdecode(destination))
 
   ## if contents is a `code tag`, then we need to move this outside
@@ -132,19 +132,19 @@ parse_link <- function(destination, contents, state) {
   ## `fun` is fun() or obj (fun is with parens)
   ## `is_fun` is TRUE for fun(), FALSE for obj
   ## `obj` is fun or obj (fun is without parens)
-  ## `s4` is TRUE if we link to an S4 class (i.e. have -class suffix)
+  ## `is_s4` is TRUE if we link to an S4 class (i.e. have -class suffix)
   ## `noclass` is fun with -class removed
   ## `file` is the file name of the linked topic.
 
   thispkg <- roxy_meta_get("current_package") %||% ""
-  is_code <- is_code || (grepl("[(][)]$", destination) && ! has_link_text)
+  is_code <- is_code || (grepl("[(][)]$", destination) && !has_link_text)
   pkg <- str_match(destination, "^(.*)::")[1,2]
   pkg <- gsub("%", "\\\\%", pkg)
   fun <- utils::tail(strsplit(destination, "::", fixed = TRUE)[[1]], 1)
   fun <- gsub("%", "\\\\%", fun)
   is_fun <- grepl("[(][)]$", fun)
   obj <- sub("[(][)]$", "", fun)
-  s4 <- str_detect(destination, "-class$")
+  is_s4 <- str_detect(destination, "-class$")
   noclass <- str_match(fun, "^(.*)-class$")[1,2]
 
   if (is.na(pkg)) pkg <- resolve_link_package(obj, thispkg, state = state)
@@ -155,14 +155,14 @@ parse_link <- function(destination, contents, state) {
   if (!has_link_text) {
     paste0(
       if (is_code) "\\code{",
-      if (s4 && is.na(pkg)) "\\linkS4class" else "\\link",
-      if (is_fun || ! is.na(pkg)) "[",
+      if (is_s4 && is.na(pkg)) "\\linkS4class" else "\\link",
+      if (is_fun || !is.na(pkg)) "[",
       if (is_fun && is.na(pkg)) "=",
-      if (! is.na(pkg)) paste0(pkg, ":"),
-      if (is_fun || ! is.na(pkg)) paste0(if (is.na(pkg)) obj else file, "]"),
+      if (!is.na(pkg)) paste0(pkg, ":"),
+      if (is_fun || !is.na(pkg)) paste0(if (is.na(pkg)) obj else file, "]"),
       "{",
       if (!is.na(pkg)) paste0(pkg, "::"),
-      if (s4) noclass else fun,
+      if (is_s4) noclass else fun,
       "}",
       if (is_code) "}" else ""
     )
@@ -282,7 +282,7 @@ find_reexport_source <- function(topic, package) {
   }
 }
 
-#' Dummy page to test roxygen's markdown formatting
+#' Dummy page to test roxygen's Markdown formatting
 #'
 #' Links are very tricky, so I'll put in some links here:
 #' Link to a function: [roxygenize()].

--- a/tests/testthat/_snaps/markdown-code.md
+++ b/tests/testthat/_snaps/markdown-code.md
@@ -15,7 +15,7 @@
       
     Message
       
-      Quitting from lines 1-1
+      Quitting from :1-1
       x <text>:4: @description failed to evaluate inline markdown code.
       Caused by error in `map_chr()`:
       i In index: 1.

--- a/tests/testthat/_snaps/object-package.md
+++ b/tests/testthat/_snaps/object-package.md
@@ -13,14 +13,23 @@
     Code
       # ORCID comments
       person_desc(comment = c(ORCID = "1234"))
+    Condition
+      Warning in `person1()`:
+      Invalid ORCID iD: '1234'.
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID})"
     Code
       person_desc(comment = c(ORCID = "https://orcid.org/1234"))
+    Condition
+      Warning in `person1()`:
+      Invalid ORCID iD: 'https://orcid.org/1234'.
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID})"
     Code
       person_desc(comment = c(ORCID = "1234", "extra"))
+    Condition
+      Warning in `person1()`:
+      Invalid ORCID iD: '1234'.
     Output
       [1] "H W \\email{h@w.com} (\\href{https://orcid.org/1234}{ORCID}) (extra)"
 

--- a/tests/testthat/_snaps/rd-include-rmd.md
+++ b/tests/testthat/_snaps/rd-include-rmd.md
@@ -20,9 +20,9 @@
       
     Message
       
-      Quitting from lines 2-3 [unnamed-chunk-2] (<temp-path.Rmd>)
+      Quitting from <temp-path.Rmd>:1-3 [unnamed-chunk-2]
       
-      Quitting from lines 2-2 [unnamed-chunk-1] (<another-temp-path.Rmd>)
+      Quitting from <another-temp-path.Rmd>:1-2 [unnamed-chunk-1]
       x <text>:3: @includeRmd failed to evaluate '<temp-path.Rmd>'.
       Caused by error:
       ! Error

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -62,7 +62,9 @@ test_that("{ and } in links are escaped (#1259)", {
   expect_equal(markdown("[foo({ bar })][x]"), "\\link[=x]{foo({ bar })}")
 })
 
-test_that("non-text nodes in links fails", {
+test_that("non-text nodes in links fails for R < 4.5.0", {
+  skip_if(getRversion() >= "4.5.0")
+
   tag <- roxy_tag("title", NULL, NULL, file = "foo.R", line = 10)
 
   expect_snapshot({


### PR DESCRIPTION
From R 4.5.0 [NEWS](https://cran.r-project.org/doc/manuals/r-release/NEWS.html):

> - The Rd `⁠\link`⁠ macro now allows markup in the link text when the topic is given by the optional argument, e.g., `⁠\link[=gamma]{\eqn{\Gamma(x)}}⁠`.

This PR adapts roxygen2 internally to allow generating such Rd markup, see 6778edad64574f7c24c81394c3d5ab037f7086b3.

Additionally, it updates unrelated test snapshots (bd6ba1afae406d2f10834ca59f4c7cae2ef85a95) and includes some cosmetic changes (4fc0a3abc34b5049bc29df6611a187b2cd2de821).

The failing test (`resolve_link_package`) is unrelated to this PR and should be fixed by #1711.