### PR TITLE
Plain markdown for chunk not intended as regular code

### DIFF
--- a/vignettes/reuse.Rmd
+++ b/vignettes/reuse.Rmd
@@ -70,7 +70,7 @@ tan_ish <- function(x) x + x^3 / 3
 Alternatively, you can add docs to an existing function.
 This tends to work better if you have a "primary" function with some variants or some helpers.
 
-```r
+```{r, eval = FALSE}
 #' Logarithms
 #' 
 #' @param x A numeric vector


### PR DESCRIPTION
`lintr::object_usage_linter()` trips up here because `...` is not being used correctly. Visually, it looks like this chunk is not intended as "normal" code even though of course it will parse perfectly well.

{codetools} reports this:

```r
log <- function(x, base) ...
codetools::checkUsage(log)
# <anonymous>: ... may be used in an incorrect context
```