### PR TITLE
Hint about lacking support for links to operators

### DIFF
--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -232,7 +232,8 @@ resolve_link_package <- function(topic, me = NULL, pkgdir = NULL, state = NULL) 
       "Once {.val {topic}} is documented, this warning goes away."),
     "i" = "Make sure that the name of the topic is spelled correctly.",
     "i" = "Always list the linked package as a dependency.",
-    "i" = "Alternatively, you can fully qualify the link with a package name."
+    "i" = "Alternatively, you can fully qualify the link with a package name.",
+    "i" = if (grepl("%", topic, fixed = TRUE)) "Note that links to operator help pages (with '%') in markdown are not supported."
   ))
 
   NA_character_


### PR DESCRIPTION
Updating from {roxygen2} 7.3.2 to 7.3.3 generated a lot of logs like:

```
✖ integer64.R:171: @returns Could not resolve link to topic "\\%/\\%" in the dependencies or base packages.
ℹ If you haven't documented "\\%/\\%" yet, or just changed its name, this is normal. Once "\\%/\\%" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
```

The current messaging is misleading / extra hard to parse due to the double-escaped `\`. It took some sleuthing to find that this is not supported: https://github.com/r-lib/roxygen2/issues/550. (I had checked the [Indexing and cross-references](https://roxygen2.r-lib.org/articles/index-crossref.html) vignette, not [(R)Markdown support]((R)Markdown support)).

Looks like this entails new shapshots -- can generate if this roughly looks good.