### PR TITLE
docs: document the `subclass` argument of `roclet()`

### DIFF
--- a/R/roclet.R
+++ b/R/roclet.R
@@ -2,6 +2,7 @@
 #'
 #' To create a new roclet, you will need to create a constructor function
 #' that wraps `roclet`, and then implement the methods described below.
+#' See `vignette("extending")` for more details.
 #'
 #' @section Methods:
 #'
@@ -35,6 +36,12 @@ NULL
 
 #' @export
 #' @rdname roclet
+#' @param subclass Class of the roclet, character vector.
+#' @examples
+#' # Custom roclet
+#' custom_roclet <- roclet("custom")
+#' # Roclet that extends the existing Rd roclet.
+#' supercharged_rd_roclet <- roclet(c("cool", "rd"))
 roclet <- function(subclass, ...) {
   structure(list(...), class = c(paste0("roclet_", subclass), "roclet"))
 }

--- a/man/roclet.Rd
+++ b/man/roclet.Rd
@@ -22,6 +22,8 @@ roclet_clean(x, base_path)
 roclet_tags(x)
 }
 \arguments{
+\item{subclass}{Class of the roclet, character vector.}
+
 \item{x}{A \code{roclet} object.}
 
 \item{blocks}{A list of \link{roxy_block} objects.}
@@ -35,6 +37,7 @@ roclet_tags(x)
 \description{
 To create a new roclet, you will need to create a constructor function
 that wraps \code{roclet}, and then implement the methods described below.
+See \code{vignette("extending")} for more details.
 }
 \section{Methods}{
 
@@ -57,4 +60,10 @@ method for each tag.
 }
 }
 
+\examples{
+# Custom roclet
+custom_roclet <- roclet("custom")
+# Roclet that extends the existing Rd roclet.
+supercharged_rd_roclet <- roclet(c("cool", "rd"))
+}
 \keyword{internal}


### PR DESCRIPTION
Fix #1741