### PR TITLE
Enable support for markup in link text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # roxygen2 (development version)
 
+* Markdown link text now supports non-code markup like bold and italic, e.g., `[*italic text*][func]` generates `\link[=func]{\emph{italic text}}`, matching R's support for markup in `\link` text in R 4.5.0.
 * `object_format()` now escapes braces in class names, fixing broken Rd output for data objects with class `{` like `quote({})` (#1744).
 * Fixed a performance regression where `roxygenize()` was very slow when the package contained large non-function objects like datasets (#1720).
 * Package documentation now correctly handles multiple arbitrary comments in the `comment` argument of `person()` in `Authors@R` (#1746).

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -111,22 +111,6 @@ parse_link <- function(destination, contents, state) {
     local_bindings(.env = state, in_link_code = TRUE)
   }
 
-  if (!all(xml_name(contents) %in% c("text", "softbreak", "linebreak"))) {
-    incorrect <- setdiff(
-      unique(xml_name(contents)),
-      c("text", "softbreak", "linebreak")
-    )
-
-    warn_roxy_tag(
-      state$tag,
-      c(
-        "markdown links must contain plain text",
-        i = "Problematic link: {destination}"
-      )
-    )
-    return("")
-  }
-
   ## If the supplied link text is the same as the reference text,
   ## then we assume that the link text was automatically generated and
   ## it was not specified explicitly. In this case `()` links are

--- a/tests/testthat/_snaps/markdown-link.md
+++ b/tests/testthat/_snaps/markdown-link.md
@@ -1,20 +1,3 @@
-# non-text nodes in links fails
-
-    Code
-      markdown("[`foo` bar][x]", tag = tag)
-    Message
-      x foo.R:10: @title (automatically generated) markdown links must contain plain text.
-      i Problematic link: x
-    Output
-      [1] ""
-    Code
-      markdown("[__baz__][x]", tag = tag)
-    Message
-      x foo.R:10: @title (automatically generated) markdown links must contain plain text.
-      i Problematic link: x
-    Output
-      [1] ""
-
 # short and sweet links work
 
     Code

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -65,13 +65,10 @@ test_that("{ and } in links are escaped (#1259)", {
   expect_equal(markdown("[foo({ bar })][x]"), r"(\link[=x]{foo({ bar })})")
 })
 
-test_that("non-text nodes in links fails", {
-  tag <- roxy_tag("title", NULL, NULL, file = "foo.R", line = 10)
-
-  expect_snapshot({
-    markdown("[`foo` bar][x]", tag = tag)
-    markdown("[__baz__][x]", tag = tag)
-  })
+test_that("non-text nodes in links are supported", {
+  expect_equal(markdown("[`foo` bar][x]"), r"(\link[=x]{\code{foo} bar})")
+  expect_equal(markdown("[__baz__][x]"), r"(\link[=x]{\strong{baz}})")
+  expect_equal(markdown("[_italic_][x]"), r"(\link[=x]{\emph{italic}})")
 })
 
 test_that("commonmark picks up the various link references", {
@@ -549,6 +546,27 @@ test_that("markup in link text", {
     #'
     #' Description, see \\code{\\link[=func]{code link text}}.
     #' And also \\href{https://external.com}{\\verb{code as well}}.
+    foo <- function() {}"
+  )[[1]]
+  expect_equivalent_rd(out1, out2)
+})
+
+test_that("non-code markup in link text", {
+  out1 <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' Title
+    #'
+    #' See [*italic text*][func] and [**bold text**][func2].
+    #' @md
+    foo <- function() {}"
+  )[[1]]
+  out2 <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' Title
+    #'
+    #' See \\link[=func]{\\emph{italic text}} and \\link[=func2]{\\strong{bold text}}.
     foo <- function() {}"
   )[[1]]
   expect_equivalent_rd(out1, out2)


### PR DESCRIPTION
As per R 4.5.0 news:

> The Rd ⁠\link⁠ macro now allows markup in the link text when the topic is given by the optional argument, e.g., ⁠\link[=gamma]{\eqn{\Gamma(x)}}⁠.

A version gate wouldn't really help here, because it's the version of R reading the docs that matters, not the version of R writing the docs. R 4.5.0 has been out for a while, and package developers need to explicitly opt-in  to this, so it feels low risk.

Replaces #1712
