### PR TITLE
Ensure `@inheritParams` can handle `\dots` in combination with other args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Fixed a performance regression where `roxygenize()` was very slow when the package contained large non-function objects like datasets (#1720).
 * Package documentation now correctly handles multiple arbitrary comments in the `comment` argument of `person()` in `Authors@R` (#1746).
 * roxygen2 now requires R 4.0 (#1632).
+* `@inheritParams` now correctly inherits parameters that are documented together with `\dots` using comma-separated names, e.g. `@param b,\dots description` (#1718).
 * `@param` (and other two-part tags) now correctly handle backtick-quoted names that contain spaces, e.g. `` @param `arg 1` description `` (#1696).
 * The warning about undocumented S3 methods no longer errors when the function lacks a srcref, e.g. because a debugger breakpoint is set (#1589, #1710).
 

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -291,9 +291,13 @@ find_params <- function(name, topics, source) {
   }
 
   param_names <- str_trim(names(params))
-  param_names[param_names == "\\dots"] <- "..."
+  param_names <- strsplit(param_names, ",\\s*")
+  param_names <- lapply(param_names, function(x) {
+    x[x == "\\dots"] <- "..."
+    x
+  })
 
-  Map(list, name = strsplit(param_names, ",\\s*"), value = unlist(params))
+  Map(list, name = param_names, value = unlist(params))
 }
 
 topic_params <- function(x) {

--- a/tests/testthat/test-rd-inherit.R
+++ b/tests/testthat/test-rd-inherit.R
@@ -507,6 +507,25 @@ test_that("@inheritParam only inherits exact multiparam matches", {
   expect_equal(out$get_value("param"), NULL)
 })
 
+test_that("@inheritParams inherits params documented with dots (#1718)", {
+  out <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' A
+    #' @param a A variable.
+    #' @param b,\\dots Parameters to pass.
+    A <- function(a, b, ...) {}
+
+    #' B
+    #' @inheritParams A
+    B <- function(a, b, ...) {}
+    "
+  )
+  expect_equal(
+    out[[2]]$get_value("param"),
+    c("a" = "A variable.", "b,..." = "Parameters to pass.")
+  )
+})
 
 test_that("@inheritParam understands compound docs", {
   out <- roc_proc_text(


### PR DESCRIPTION
Fixes #1718