### PR TITLE
S4 generics are not S3 generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * roxygen2 now requires R 4.0 (#1632).
 * `@param` (and other two-part tags) now correctly handle backtick-quoted names that contain spaces, e.g. `` @param `arg 1` description `` (#1696).
 * The warning about undocumented S3 methods no longer errors when the function lacks a srcref, e.g. because a debugger breakpoint is set (#1589, #1710).
+* The warning about undocumented S3 methods no longer incorrectly flags S4 methods of S3 generics as unexported (#1715).
 
 # roxygen2 7.3.3
 

--- a/R/object-s3.R
+++ b/R/object-s3.R
@@ -75,6 +75,11 @@ is.s3generic <- function(x) inherits(x, "s3generic")
 is.s3 <- function(x) inherits(x, c("s3method", "s3generic"))
 
 find_generic <- function(name, env = parent.frame()) {
+  # If it's an S4 generic, it's definitely not an S3 method
+  if (methods::isGeneric(name, where = env)) {
+    return(NULL)
+  }
+
   pieces <- str_split(name, fixed("."))[[1]]
   n <- length(pieces)
 

--- a/tests/testthat/test-object-s3.R
+++ b/tests/testthat/test-object-s3.R
@@ -46,6 +46,16 @@ test_that("user defined generics detected even if use non-standard", {
   expect_true(is_s3_generic("my_method"))
 })
 
+test_that("S4 generics are not treated as S3 methods", {
+  env <- new.env(parent = globalenv())
+  env$all.equal <- {
+    methods::setGeneric("all.equal")
+    all.equal
+  }
+
+  expect_false(is_s3_method("all.equal", env))
+})
+
 test_that("user defined functions override primitives", {
   c <- function(x) x + 1
   c.test <- function(x) x + 3


### PR DESCRIPTION
This handles the case where the user turns an S3 generic into an S4 generic in order to add methods for it

Fixes #1715