### PR TITLE
Warn if no `@inheritDotParams` doesn't inherit anything

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # roxygen2 (development version)
 
+* `@inheritDotParams` now warns and produces no output when there are no parameters to inherit, instead of generating an empty `\describe` block that caused CRAN HTML validation warnings (#1671).
 * `@description` no longer errors when the markdown text starts with a heading (#1705).
 * Markdown horizontal rules (e.g. `----`) now generate a clear warning instead of an internal error about an unknown `thematic_break` xml node (#1707).
 * Markdown link text now supports non-code markup like bold and italic, e.g., `[*italic text*][func]` generates `\link[=func]{\emph{italic text}}`, matching R's support for markup in `\link` text in R 4.5.0.

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -233,6 +233,17 @@ inherit_dot_params <- function(topic, topics, env) {
   non_documented_params <- setdiff(names(docs_selected), documented)
   docs_selected <- docs_selected[non_documented_params]
 
+  if (length(docs_selected) == 0) {
+    warn_roxy_topic(
+      topic$get_name(),
+      c(
+        x = "@inheritDotParams failed",
+        i = "No arguments inherited from {.fn {inheritors$source}}."
+      )
+    )
+    return()
+  }
+
   # Build the Rd
   # (1) Link to function(s) that was inherited from
   src <- inheritors$source

--- a/tests/testthat/_snaps/rd-inherit.md
+++ b/tests/testthat/_snaps/rd-inherit.md
@@ -73,6 +73,16 @@
       x In topic 'bar': @inheritDotsParam failed.
       Caused by error in `FUN()`:
       ! object 'z' not found
+      x In topic 'bar': @inheritDotParams failed.
+      i No arguments inherited from `foo()`.
+
+# warns when no params to inherit (#1671)
+
+    Code
+      out <- roc_proc_text(rd_roclet(), text)
+    Message
+      x In topic 'bar': @inheritDotParams failed.
+      i No arguments inherited from `foo()`.
 
 # useful warnings if can't find topics
 

--- a/tests/testthat/test-rd-inherit.R
+++ b/tests/testthat/test-rd-inherit.R
@@ -772,6 +772,23 @@ test_that("useful error for bad inherits", {
   expect_snapshot(. <- roc_proc_text(rd_roclet(), text))
 })
 
+test_that("warns when no params to inherit (#1671)", {
+  text <- "
+    #' Foo
+    #'
+    #' @param ... not used
+    foo <- function(...) {}
+
+    #' Bar
+    #'
+    #' @param y y
+    #' @inheritDotParams foo
+    bar <- function(y, ...) {}
+  "
+  expect_snapshot(out <- roc_proc_text(rd_roclet(), text))
+  expect_false("..." %in% names(out[["bar.Rd"]]$get_value("param")))
+})
+
 
 # inherit everything ------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1671