### PR TITLE
Handle strings after matched braces in comments in `@examples`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # roxygen2 (development version)
 
+* `@examples` no longer warns about unmatched braces when braces appear inside strings within R comments, e.g. `# '{greeting}'` (#1492).
 * `@inheritParams` now correctly updates `\linkS4class{}` links when inheriting parameter documentation from other packages, converting them to absolute links (#1634).
 * Package documentation now lists a person with both `"aut"` and `"cre"` roles in both the Maintainer and Authors sections (#1588).
 * Markdown links now do a better job of resolving package names: the process is cached for better performance (#1724); it works with infix operators (e.g. `[%in%]`) (#1728); no longer changes the link text (#1662); and includes base packages when reporting ambiguous functions (#1725).

--- a/src/isComplete.cpp
+++ b/src/isComplete.cpp
@@ -80,19 +80,15 @@ int roxygen_parse_tag(std::string string, bool is_code = false, int mode = 0) {
       break;
 
     case State::RComment:
-      // Inside R comments, braces must match.
-      // R comments are terminated by newline or } not matched by {
+      // We don't trace braces in comment independently to make it possible to
+      // close a multi-line Rd expression in a comment. This is a hack that 
+      // needed to support @examplesIf
       if (cur == '\n') {
         state = State::Rd;
-        r_braces = 0;
       } else if (cur == '{') {
         braces++;
-        r_braces++;
       } else if (cur == '}') {
         braces--;
-        r_braces--;
-        if (r_braces == 0)
-          state = State::Rd;
       }
       break;
 

--- a/tests/testthat/test-isComplete.R
+++ b/tests/testthat/test-isComplete.R
@@ -56,6 +56,10 @@ test_that("strings in code comments don't need to be closed", {
 test_that("braces in code must match", {
   expect_false(rdComplete("# {", is_code = TRUE))
   expect_true(rdComplete("# {}", is_code = TRUE))
+  expect_false(rdComplete("# {} {", is_code = TRUE))
+
+  # Allow user to close a brace in a comment (needed by `@examplesIf`)
+  expect_true(rdComplete("{ # }", is_code = TRUE))
 })
 
 # findEndOfTag -------------------------------------------------------------

--- a/tests/testthat/test-rd-examples.R
+++ b/tests/testthat/test-rd-examples.R
@@ -111,6 +111,19 @@ test_that("@examplesIf warns about unparseable condition", {
   expect_snapshot(. <- roc_proc_text(rd_roclet(), block))
 })
 
+test_that("strings in R comments don't affect brace matching (#1492)", {
+  out <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' @name a
+    #' @title a
+    #' @examples
+    #' # {greeting}'
+    NULL"
+  )[[1]]
+  expect_equal(out$get_value("examples"), rd("# {greeting}'"))
+})
+
 test_that("% in @examples escaped before matching braces test (#213)", {
   block <- "
     #' @name a


### PR DESCRIPTION
Fixes #1492