### PR TITLE
Link to topics, not filenames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   * Inline R code (`` `r expr` ``) in non-indented list continuation lines no longer causes an error (#1651).
   * Link text now supports non-code markup like bold and italic, e.g., `[*italic text*][func]` generates `\link[=func]{\emph{italic text}}`, matching R's support for markup in `\link` text in R 4.5.0.
   * Links now do a better job of resolving package names: the process is cached for better performance (#1724); it works with infix operators (e.g. `[%in%]`) (#1728); no longer changes the link text (#1662); and includes base packages when reporting ambiguous functions (#1725).
+  * Links to external packages now use the topic alias instead of the Rd file name as the anchor. This fixes "Non-topic package-anchored link(s)" notes from R CMD check (#1709).
 * Package documentation improvements:
   * Correctly handles multiple arbitrary comments in the `comment` argument of `person()` in `Authors@R` (#1746).
   * Multiple email addresses in `Authors@R` now generate separate `\email{}` tags instead of a single comma-separated one (#1689).

--- a/R/markdown-link.R
+++ b/R/markdown-link.R
@@ -121,12 +121,11 @@ parse_link <- function(destination, contents, state) {
 
   ## if (is_code) then we'll need \\code
   ## `pkg` is package or NA
-  ## `fun` is fun() or obj (fun is with parens)
-  ## `is_fun` is TRUE for fun(), FALSE for obj
-  ## `obj` is fun or obj (fun is without parens)
+  ## `fun` is fun() or topic (fun is with parens)
+  ## `is_fun` is TRUE for fun(), FALSE for topic
+  ## `topic` is fun or topic (fun is without parens)
   ## `s4` is TRUE if we link to an S4 class (i.e. have -class suffix)
   ## `noclass` is fun with -class removed
-  ## `file` is the file name of the linked topic.
 
   thispkg <- roxy_meta_get("current_package") %||% ""
   is_code <- is_code || (grepl("[(][)]$", destination) && !has_link_text)
@@ -134,21 +133,22 @@ parse_link <- function(destination, contents, state) {
   explicit_pkg <- !is.na(pkg)
   fun <- utils::tail(strsplit(destination, "::", fixed = TRUE)[[1]], 1)
   is_fun <- grepl("[(][)]$", fun)
-  obj <- sub("[(][)]$", "", fun)
+  topic <- sub("[(][)]$", "", fun)
   s4 <- str_detect(destination, "-class$")
   noclass <- str_match(fun, "^(.*)-class$")[1, 2]
 
   # Lookup topic using unescaped names, then escape % for Rd output
   if (is.na(pkg)) {
-    pkg <- find_package(obj, tag = state$tag)
+    pkg <- find_package(topic, tag = state$tag)
   } else if (!is.na(pkg) && pkg == thispkg) {
     pkg <- NA_character_
   }
-  file <- find_topic_filename(pkg, obj, state$tag)
+  # Called for its side-effect of checking that the topic exists
+  find_topic_filename(pkg, topic, state$tag)
 
   pkg <- gsub("%", "\\\\%", pkg)
   fun <- gsub("%", "\\\\%", fun)
-  obj <- gsub("%", "\\\\%", obj)
+  topic <- gsub("%", "\\\\%", topic)
   noclass <- gsub("%", "\\\\%", noclass)
 
   ## To understand this, look at the RD column of the table above
@@ -159,7 +159,7 @@ parse_link <- function(destination, contents, state) {
       if (is_fun || !is.na(pkg)) "[",
       if (is_fun && is.na(pkg)) "=",
       if (!is.na(pkg)) paste0(pkg, ":"),
-      if (is_fun || !is.na(pkg)) paste0(if (is.na(pkg)) obj else file, "]"),
+      if (is_fun || !is.na(pkg)) paste0(topic, "]"),
       "{",
       if (explicit_pkg && !is.na(pkg)) paste0(pkg, "::"),
       if (s4) noclass else fun,
@@ -174,7 +174,7 @@ parse_link <- function(destination, contents, state) {
         if (is_code) "\\code{",
         "\\link[",
         if (is.na(pkg)) "=" else paste0(pkg, ":"),
-        if (is.na(pkg)) obj else file,
+        topic,
         "]{"
       ),
       contents,

--- a/R/rd-find-link-files.R
+++ b/R/rd-find-link-files.R
@@ -42,12 +42,12 @@ find_topic_filename <- function(pkg, topic, tag = NULL) {
 #' @noRd
 
 find_topic_in_package <- function(pkg, topic) {
-  # This is needed because we have the escaped text here, and parse_Rd will
-  # un-escape it properly.
-  on.exit(close(con), add = TRUE)
-  con <- textConnection(topic)
-  raw_topic <- str_trim(tools::parse_Rd(con)[[1]][1])
-  basename(utils::help((raw_topic), (pkg))[1])
+  help_path <- utils::help((topic), (pkg))[1]
+  if (is.na(basename(help_path))) {
+    NA_character_
+  } else {
+    topic
+  }
 }
 
 try_find_topic_in_package <- function(pkg, topic, tag) {

--- a/tests/testthat/test-markdown-link.R
+++ b/tests/testthat/test-markdown-link.R
@@ -51,9 +51,16 @@ test_that("% in links are escaped", {
   expect_equal(markdown("[x][%%]"), r"(\link[=\%\%]{x})")
   expect_equal(markdown("[%][x]"), r"(\link[=x]{\%})")
   expect_equal(markdown("[%%]"), r"(\link{\%\%})")
-  expect_equal(markdown("[base::%%]"), r"(\link[base:Arithmetic]{base::\%\%})")
+  expect_equal(markdown("[base::%%]"), r"(\link[base:\%\%]{base::\%\%})")
   # %in% can be resolved to base package (#1728)
   expect_equal(markdown("[%in%]"), r"(\link{\%in\%})")
+})
+
+test_that("links to topic, not filename", {
+  expect_equal(
+    markdown("[tools::CRAN_package_db]"),
+    r"(\link[tools:CRAN_package_db]{tools::CRAN_package_db})"
+  )
 })
 
 test_that("{ and } in links are escaped (#1259)", {

--- a/tests/testthat/test-object-import.R
+++ b/tests/testthat/test-object-import.R
@@ -35,7 +35,7 @@ test_that("multiple re-exports are combined", {
     rd_section_reexport(
       c("testthat", "testthat"),
       c("expect_lt", "expect_gt"),
-      c("comparison-expectations", "comparison-expectations")
+      c("expect_lt", "expect_gt")
     )
   )
 })


### PR DESCRIPTION
Fixes #1709

@gaborcsardi could you please double check this? My reading of R-exts suggests that as of R 4.1 we should provide topics, not file names. 