### PR TITLE
Fix R6 edge case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `@examplesIf` now warns when there is no example code after the condition (#1695).
 * `tag_words_line()` is deprecated in favour of `tag_words()`, which now checks for single-line content by default. Use `tag_words(x, multiline = TRUE)` or `tag_value(x, multiline = TRUE)` if your tag legitimately spans multiple lines.
 * R6 improvements:
+  * R6 classes with only active bindings and `cloneable = FALSE` no longer error during documentation (#1610).
   * `initialize()` method parameters now automatically inherit documentation from `@field` tags with the same name, reducing the need to duplicate descriptions. Explicit `@param` tags still take precedence (#1004).
 * New `needs_roxygenize()` provides a lightweight check that man pages are up-to-date by comparing modification times of `.Rd` files with their source files (#1411).
 * All generated links now use the same code path. This will lead to some minor differences when you re-document, but overall the links will now be more consistent (#1792).

--- a/R/rd-r6-methods.R
+++ b/R/rd-r6-methods.R
@@ -115,6 +115,9 @@ add_default_methods <- function(methods, block) {
 }
 
 find_method_for_tag <- function(methods, tag) {
+  if (nrow(methods) == 0) {
+    return(NA_character_)
+  }
   w <- which(
     basename(methods$file) == basename(tag$file) &
       methods$line > tag$line

--- a/tests/testthat/test-rd-r6-class.R
+++ b/tests/testthat/test-rd-r6-class.R
@@ -12,6 +12,20 @@ test_that("can construct empty class", {
   expect_equal(docs$active_bindings, rd_r6_bindings())
 })
 
+test_that("class with only active bindings doesn't error (#1610)", {
+  text <- "
+    #' Class
+    C <- R6::R6Class('C',
+      active = list(
+        #' @field x A value.
+        x = function(val) val
+      ),
+      cloneable = FALSE
+    )"
+  docs <- r6_doc(text)
+  expect_equal(docs$methods, rd_r6_methods("C"))
+})
+
 test_that("warns about unmatched components ", {
   text <- "
     #' Class


### PR DESCRIPTION
Previously a class with no methods, not-cloneable, and some active bindings would error.

Fixes #1610.