### PR TITLE
document rstudio reliance in inheritDotParams

### DIFF
--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -278,6 +278,7 @@ inherit_dot_params <- function(topic, topics, env) {
     collapse = "\n"
   )
 
+  # NOTE: this rd structure is used by RStudio for parameter completions
   rd <- paste0(
     "\n",
     "  Arguments passed on to ",


### PR DESCRIPTION
So that we don't break RStudio completions down the line.

Related: https://github.com/r-lib/roxygen2/issues/1808