### PR TITLE
Use `match_param()` in `inherit_dot_params()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 * `@family` no longer adds a trailing space after the colon in the default family prefix (#1628). Custom `rd_family_title` values now automatically get a colon appended if they don't already end with one (#1656).
 * `@inheritDotParams` now generates an informative warning when the source function can't be found, instead of a cryptic error (#1602).
 * `@inheritDotParams` now warns and produces no output when there are no parameters to inherit, instead of generating an empty `\describe` block that caused CRAN HTML validation warnings (#1671).
+* `@inheritDotParams` now correctly matches parameters that are documented with a dot-prefixed alias (e.g., `.by, by`) but whose formal argument lacks the dot (e.g., `by`), as is common in the tidyverse (#1826).
 * `@inheritParams` now correctly inherits parameters that are documented together with `\dots` using comma-separated names, e.g. `@param b,\dots description` (#1718).
 * `@inheritParams` now correctly updates `\linkS4class{}` links when inheriting parameter documentation from other packages, converting them to absolute links (#1634).
 * `@param` (and other two-part tags) now correctly handle backtick-quoted names that contain spaces, e.g. `` @param `arg 1` description `` (#1696).

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -229,11 +229,11 @@ inherit_dot_params <- function(topic, topics, env) {
     tag = "@inheritDotParams"
   )
   arg_matches <- function(args, docs) {
-    match <- map_lgl(docs, \(x) all(x$name %in% args))
-    matched <- docs[match]
+    matched_names <- lapply(docs, \(x) match_param(x$name, args))
+    match <- !map_lgl(matched_names, is.null)
     setNames(
-      lapply(matched, "[[", "value"),
-      map_chr(matched, \(x) paste(x$name, collapse = ","))
+      lapply(docs[match], "[[", "value"),
+      map_chr(matched_names[match], paste, collapse = ",")
     )
   }
   docs_selected <- unlist(map2(args, docs, arg_matches))

--- a/tests/testthat/test-rd-inherit.R
+++ b/tests/testthat/test-rd-inherit.R
@@ -817,6 +817,27 @@ test_that("warns when no params to inherit (#1671)", {
   expect_false("..." %in% names(out[["bar.Rd"]]$get_value("param")))
 })
 
+test_that("inheritDotParams matches when doc uses dotted name but formal doesn't (#1826)", {
+  out <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' Foo
+    #'
+    #' @param x x
+    #' @param .y,y doc for y
+    foo <- function(x, y) {}
+
+    #' Bar
+    #'
+    #' @inheritDotParams foo
+    bar <- function(...) {}
+  "
+  )[[2]]
+
+  dot_param <- out$get_value("param")[["..."]]
+  expect_match(dot_param, "item{\\code{y}}", fixed = TRUE)
+})
+
 test_that("inheritDotParams warns when source not found (#1602)", {
   text <- "
     #' Test


### PR DESCRIPTION
Fixes #1826