### PR TITLE
Deploy a targeted fix for `all.equal()` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 * roxygen2 no longer depends on purrr.
 * roxygen2 now requires R 4.1 (#1632).
 * S3 method handling improvements:
-  * Method parsing now prefers the longest matching generic name, so e.g. `all.equal.numeric` is correctly identified as a method of `all.equal` rather than `all` (#1587).
+  * Methods of `all.equal()` (e.g. `all.equal.numeric`) are now correctly identified as methods of `all.equal()`, `all()` (#1587).
   * The warning about undocumented methods no longer errors when the function lacks a srcref, e.g. because a debugger breakpoint is set (#1589, #1710).
   * The warning about undocumented methods no longer incorrectly flags S4 methods of S3 generics as unexported (#1715).
 * `@description` no longer errors when the markdown text starts with a heading (#1705).

--- a/R/object-s3.R
+++ b/R/object-s3.R
@@ -80,6 +80,12 @@ find_generic <- function(name, env = parent.frame()) {
     return(NULL)
   }
 
+  # special case all.equal() methods to avoid treating as all() methods (#1587)
+  if (startsWith(name, "all.equal.") && is_s3_generic("all.equal", env)) {
+    method <- substr(name, nchar("all.equal.") + 1, nchar(name))
+    return(c("all.equal", method))
+  }
+
   pieces <- str_split(name, fixed("."))[[1]]
   n <- length(pieces)
 
@@ -88,7 +94,7 @@ find_generic <- function(name, env = parent.frame()) {
     return(NULL)
   }
 
-  for (i in rev(seq_len(n - 1))) {
+  for (i in seq_len(n - 1)) {
     generic <- paste0(pieces[seq_len(i)], collapse = ".")
     class <- paste0(pieces[(i + 1):n], collapse = ".")
 

--- a/tests/testthat/test-object-s3.R
+++ b/tests/testthat/test-object-s3.R
@@ -57,8 +57,12 @@ test_that("S4 generics are not treated as S3 methods", {
   expect_false(is_s3_method("all.equal", env))
 })
 
-test_that("find_generic prefers longest generic name", {
+test_that("all.equal is matched correctly", {
   expect_equal(find_generic("all.equal.numeric"), c("all.equal", "numeric"))
+  expect_equal(
+    find_generic("all.equal.data.frame"),
+    c("all.equal", "data.frame")
+  )
 })
 
 test_that("user defined functions override primitives", {


### PR DESCRIPTION
Fixes #1587