### PR TITLE
Drop warning for `R` inline code usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,6 @@
 * `` `Rd expr` `` inline code now generates `\Sexpr[stage=render,results=rd]{expr}`, providing a convenient syntax for evaluating R code at documentation render time (#1214).
 * Indented bullet lists in `@param` and other two-part tags are no longer incorrectly nested (#1102).
 * Horizontal rules (e.g. `----`) now generate a clear warning instead of an internal error about an unknown `thematic_break` xml node (#1707).
-* Inline code with uppercase `` `R ` `` now warns that you should use lowercase `` `r ` `` instead, since knitr only supports lowercase.
 * Inline R code (`` `r expr` ``) in non-indented list continuation lines no longer causes an error (#1651).
 * Link text now supports non-code markup like bold and italic, e.g., `[*italic text*][func]` generates `\link[=func]{\emph{italic text}}`, matching R's support for markup in `\link` text in R 4.5.0.
 * Links now do a better job of resolving package names: the process is cached for better performance (#1724); it works with infix operators (e.g. `[%in%]`) (#1728); no longer changes the link text (#1662); and includes base packages when reporting ambiguous functions (#1725). Links to external packages now use the topic alias instead of the Rd file name as the anchor. This fixes "Non-topic package-anchored link(s)" notes from R CMD check (#1709).

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -335,10 +335,6 @@ mdxml_break <- function(state) {
 mdxml_code <- function(xml, tag) {
   code <- xml_text(xml)
 
-  if (grepl("^R ", code)) {
-    warn_roxy_tag(tag$tag, "use ` r`, not `R `, for inline code")
-  }
-
   if (grepl("^Rd ", code)) {
     paste0(
       "\\Sexpr[stage=render,results=rd]{",

--- a/tests/testthat/_snaps/markdown-code.md
+++ b/tests/testthat/_snaps/markdown-code.md
@@ -1,10 +1,3 @@
-# uppercase R in inline code gives warning
-
-    Code
-      . <- roc_proc_text(rd_roclet(), text)
-    Message
-      x <text>:2: @title use `r `, not `R `, for inline code.
-
 # multi-line inline code gives useful warning
 
     Code

--- a/tests/testthat/_snaps/markdown-code.md
+++ b/tests/testthat/_snaps/markdown-code.md
@@ -3,7 +3,7 @@
     Code
       . <- roc_proc_text(rd_roclet(), text)
     Message
-      x <text>:2: @title use ` r`, not `R `, for inline code.
+      x <text>:2: @title use `r `, not `R `, for inline code.
 
 # multi-line inline code gives useful warning
 

--- a/tests/testthat/test-markdown-code.R
+++ b/tests/testthat/test-markdown-code.R
@@ -30,15 +30,6 @@ test_that("can eval inline code", {
   expect_equal(out1$get_value("description"), "Description 4")
 })
 
-test_that("uppercase R in inline code gives warning", {
-  text <- "
-    #' @title Title `R 1 + 1`
-    #' @md
-    foo <- function() NULL
-  "
-  expect_snapshot(. <- roc_proc_text(rd_roclet(), text))
-})
-
 test_that("can eval fenced code", {
   out1 <- roc_proc_text(
     rd_roclet(),


### PR DESCRIPTION
Since it's common to write (e.g.) `` `R CMD check` ``