### PR TITLE
Remove unused 'r_braces'

### DIFF
--- a/src/isComplete.cpp
+++ b/src/isComplete.cpp
@@ -85,7 +85,7 @@ int roxygen_parse_tag(std::string string, bool is_code = false, int mode = 0, in
 
   State state = State::Rd;
   char string_delim = '\0';
-  int braces = 0, r_braces = 0;
+  int braces = 0;
 
   for (int i = start; i < n; i++) {
     char cur = string[i];


### PR DESCRIPTION
As flagged by `clang`'s `-Wunused-variable`. Dropped in cc725ffa10e35aa3f81b572c19a0d94e489c2579.