### PR TITLE
Better handling for S7 `[`/`[<-` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # roxygen2 (development version)
 
+* S7 methods for `[`, `[[`, `[<-`, and `[[<-` now generate valid usage (#1883).
 * The automatic usage for a data object that is conditional on the `LazyData` option in the `DESCRIPTION` (see below) now correctly detects all ways to specify a true value, e.g. also `yes`, `Yes` or `True` (@jranke, #1881).
 
 # roxygen2 8.0.0

--- a/R/rd-usage.R
+++ b/R/rd-usage.R
@@ -107,7 +107,17 @@ object_usage.s7method <- function(x) {
 # function, s3 method, s4 method, data
 
 function_usage <- function(name, formals, format_name = identity) {
-  if (is_replacement_fun(name) && !is_infix_fun(name)) {
+  if (is_bracket_fun(name) && identical(format_name, identity)) {
+    # `[`, `[[`, and their replacement forms have no Rd method macro, so we
+    # render them directly using subsetting syntax, e.g. `x[i, ...]`.
+    if (is_replacement_fun(name)) {
+      name <- sub("<-", "", name, fixed = TRUE)
+      formals$value <- NULL
+      bracket_usage(name, formals, suffix = " <- value")
+    } else {
+      bracket_usage(name, formals)
+    }
+  } else if (is_replacement_fun(name) && !is_infix_fun(name)) {
     name <- sub("<-", "", name, fixed = TRUE)
     if (identical(format_name, identity)) {
       name <- auto_backtick(name)
@@ -135,6 +145,17 @@ function_usage <- function(name, formals, format_name = identity) {
 
 is_replacement_fun <- function(name) {
   grepl("<-", name, fixed = TRUE)
+}
+is_bracket_fun <- function(name) {
+  name %in% c("[", "[[", "[<-", "[[<-")
+}
+
+bracket_usage <- function(name, formals, suffix = NULL) {
+  close <- if (name == "[[") "]]" else "]"
+  args <- args_string(usage_args(formals))
+  obj <- args[[1]]
+  inner <- paste0(args[-1], collapse = ", ")
+  rd(paste0(obj, name, inner, close, suffix))
 }
 is_infix_fun <- function(name) {
   ops <- c(

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -542,6 +542,42 @@ test_that("S7 union method usage shows member classes", {
   )
 })
 
+test_that("S7 bracket methods use subsetting syntax", {
+  skip_unless_r(">= 4.3.0")
+  expect_equal(
+    call_to_usage({
+      Vec <- S7::new_class("Vec")
+      `[` <- S7::new_generic("[", "x")
+      S7::method(`[`, Vec) <- function(x, i, ...) x
+    }),
+    "## S7 method for class <Vec>\nx[i, ...]"
+  )
+  expect_equal(
+    call_to_usage({
+      Vec <- S7::new_class("Vec")
+      `[<-` <- S7::new_generic("[<-", "x")
+      S7::method(`[<-`, Vec) <- function(x, i, ..., value) x
+    }),
+    "## S7 method for class <Vec>\nx[i, ...] <- value"
+  )
+  expect_equal(
+    call_to_usage({
+      Vec <- S7::new_class("Vec")
+      `[[` <- S7::new_generic("[[", "x")
+      S7::method(`[[`, Vec) <- function(x, i) x
+    }),
+    "## S7 method for class <Vec>\nx[[i]]"
+  )
+  expect_equal(
+    call_to_usage({
+      Vec <- S7::new_class("Vec")
+      `[[<-` <- S7::new_generic("[[<-", "x")
+      S7::method(`[[<-`, Vec) <- function(x, i, value) x
+    }),
+    "## S7 method for class <Vec>\nx[[i]] <- value"
+  )
+})
+
 test_that("preserves non-breaking-space", {
   expect_equal(
     call_to_usage(f <- function(a = "\u{A0}") {}),


### PR DESCRIPTION
This is S7 specific because the `\method{}` and `\S4method{}` macros handle it for S3 and S4

Fixes #1883