### PR TITLE
Use `@returns` in getting started vignette

### DIFF
--- a/vignettes/roxygen2.Rmd
+++ b/vignettes/roxygen2.Rmd
@@ -81,7 +81,7 @@ example <- "#' Add together two numbers
 #'
 #' @param x A number.
 #' @param y A number.
-#' @return A number.
+#' @returns A number.
 #' @export
 #' @examples
 #' add(1, 1)


### PR DESCRIPTION
The [documentation](https://roxygen2.r-lib.org/reference/tags-rd-functions.html) states that `@return` is superseded by `@returns`. `@returns` is indeed consistently used throughout, except in this getting started vignette.