### PR TITLE
Support setAs() and setGroupGeneric()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Markdown processing now handles multibyte characters inside Rd tags correctly; previously a tag like `\code{café}` would corrupt the markdown interpretation of the text that followed it.
 * Markdown warnings triggered by a `rd_family_title` prefix (e.g. for an unsupported level 1 heading) no longer error.
 * Markdown link targets and inherited Rd topics are now resolved with cached indexes provided by the new rdtools package, replacing repeated `help()` calls and roxygen2's own topic lookup and package-qualification code. This substantially speeds up packages with many cross-references, e.g. Rd generation for testthat is nearly twice as fast.
+* `setAs()` and `setGroupGeneric()` are now recognised, so they get the same automatic alias and `\usage` as `setMethod()` and `setGeneric()`, fixing the "Rd files without \usage" note from `R CMD check` (#1908).
 * S7 methods for `[`, `[[`, `[<-`, and `[[<-` now generate valid usage (#1883).
 * `Config/roxygen2/` flag fields in `DESCRIPTION` (like `markdown`) are now parsed case-insensitively, so `true` and `True` work as well as `TRUE`, and an invalid value gives a clear error (#1875).
 * `@section` titles can now contain code that includes a colon (#1878).

--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -30,10 +30,14 @@ object_from_call <- function(call, env, block, file) {
       "setRefClass" = parser_setRefClass(call, env, block),
       "methods::setGeneric" = ,
       "setGeneric" = parser_setGeneric(call, env, block),
+      "methods::setGroupGeneric" = ,
+      "setGroupGeneric" = parser_setGeneric(call, env, block),
       "methods::setMethod" = ,
       "setMethod" = parser_setMethod(call, env, block),
       "methods::setReplaceMethod" = ,
       "setReplaceMethod" = parser_setReplaceMethod(call, env, block),
+      "methods::setAs" = ,
+      "setAs" = parser_setAs(call, env, block),
 
       "R.methodsS3::setMethodS3" = ,
       "setMethodS3" = parser_setMethodS3(call, env, block),
@@ -204,6 +208,16 @@ parser_setMethod <- function(call, env, block) {
 parser_setReplaceMethod <- function(call, env, block) {
   name <- paste0(as.character(call$f), "<-")
   value <- methods::getMethod(name, eval(call[[3]]), where = env)
+  value@.Data <- extract_method_fun(value@.Data)
+
+  object(value, NULL, "s4method")
+}
+
+# setAs() defines a method for the coerce() generic (and, if `replace` is
+# supplied, for coerce<-(), which we don't document).
+parser_setAs <- function(call, env, block) {
+  signature <- c(eval(call$from, env), eval(call$to, env))
+  value <- methods::getMethod("coerce", signature, where = env)
   value@.Data <- extract_method_fun(value@.Data)
 
   object(value, NULL, "s4method")

--- a/tests/testthat/test-object-from-call.R
+++ b/tests/testthat/test-object-from-call.R
@@ -193,6 +193,20 @@ test_that("finds S4 generics and methods", {
     setReplaceMethod("bar", "Foo", function(x, value) {})
   })
   expect_s3_class(obj, "s4method")
+
+  obj <- call_to_object({
+    setGroupGeneric("Quux", function(e1, e2) NULL)
+  })
+  expect_s3_class(obj, "s4generic")
+})
+
+test_that("finds S4 coercion methods", {
+  obj <- call_to_object({
+    setClass("Foo", representation(x = "numeric"))
+    setAs("numeric", "Foo", function(from) new("Foo", x = from))
+  })
+  expect_s3_class(obj, "s4method")
+  expect_equal(obj$topic, "coerce,numeric,Foo-method")
 })
 
 test_that("finds correct parser even when namespaced", {
@@ -200,6 +214,12 @@ test_that("finds correct parser even when namespaced", {
     setClass("Foo")
     setGeneric("baz", function(x) standardGeneric("baz"))
     methods::setMethod('baz', 'Foo', function(x) {})
+  })
+  expect_s3_class(obj, "s4method")
+
+  obj <- call_to_object({
+    setClass("Foo", representation(x = "numeric"))
+    methods::setAs("numeric", "Foo", function(from) new("Foo", x = from))
   })
   expect_s3_class(obj, "s4method")
 })

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -286,6 +286,16 @@ test_that("default usage correct for S4 methods", {
   )
 })
 
+test_that("default usage correct for S4 coercion methods", {
+  expect_equal(
+    call_to_usage({
+      setClass("Foo", representation(x = "numeric"))
+      setAs("numeric", "Foo", function(from) new("Foo", x = from))
+    }),
+    r"(\S4method{coerce}{numeric,Foo}(from, to = "Foo", strict = TRUE))"
+  )
+})
+
 test_that("default usage correct for S4 methods with different args to generic", {
   expect_equal(
     call_to_usage({

--- a/vignettes/rd-S4.Rmd
+++ b/vignettes/rd-S4.Rmd
@@ -30,6 +30,13 @@ S4 **generics** are functions, so document them as such.
 `@export` a generic if you want users to call it or other developers to write methods for it.
 If the generic is internal, you don't need to export or document it.
 
+### Supported syntax
+
+- `setGeneric("balance", function(x) standardGeneric("balance"))`
+
+- `setGroupGeneric("Ops2", function(e1, e2) ...)`, which defines a group
+  generic and is otherwise documented just like `setGeneric()`.
+
 ## Classes
 
 Document **S4 classes** by adding a roxygen block before `setClass()`.
@@ -47,6 +54,13 @@ Here's a simple example:
 #' @export
 Account <- setClass("Account", slots = list(balance = "numeric"))
 ```
+
+### Supported syntax
+
+- `setClass("Account", slots = list(balance = "numeric"))`
+
+- `setClassUnion("Number", c("numeric", "integer"))`, which defines a class
+  and is otherwise documented just like `setClass()`.
 
 ## Methods
 
@@ -67,3 +81,18 @@ You can document methods in three places:
 
 Use either `@rdname` or `@describeIn` to control where method documentation goes.
 See `vignette("reuse")` for more details.
+
+### Supported syntax
+
+- `setMethod("show", "Account", function(object) ...)`
+
+- `setReplaceMethod("balance", "Account", function(x, value) ...)`, which
+  documents the `balance<-` method, aliased as
+  `balance<-,Account-method`.
+
+- `setAs("numeric", "Account", function(from) ...)`, which documents the
+  `coerce()` method. The usage comes from `coerce()`, so must you document
+  `@param to` and `@param strict` even if your definition only takes `from`.
+
+   If you supply `replace`, only the `coerce()` method is documented; use
+  `@aliases` if you also want to document `coerce<-`.


### PR DESCRIPTION
roxygen2 didn't recognise `setAs()` or `setGroupGeneric()`, so a roxygen block in front of either produced an Rd file with no `\usage` — which current R-devel reports as `Rd files without \usage`. `setAs()` also got no method alias. Both now behave like `setMethod()` and `setGeneric()`:

```
\name{coerce,numeric,Account-method}
\alias{coerce,numeric,Account-method}
\usage{
\S4method{coerce}{numeric,Account}(from, to = "Account", strict = TRUE)
}
```

Fixes #1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
