### PR TITLE
Fix `@inheritParams` with multiple filtered tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * The automatic usage for a data object that is conditional on the `LazyData` option in the `DESCRIPTION` (see below) now correctly detects all ways to specify a true value, e.g. also `yes`, `Yes` or `True` (@jranke, #1881).
 * `@import` now inserts the directive as is into `NAMESPACE` when it contains a comma, making it possible to use other forms like `@import rlang, except = ":="`.
 * `@importFrom` now generates a single multiline `importFrom()` directive per package instead of one directive per symbol. This fixes a performance issue with `loadNamespace()` for packages that import many symbols.
-* `@inheritParams` no longer errors when a topic uses argument selection in more than one tag, e.g. `@inheritParams a x` followed by `@inheritParams b y` (#1879). If the same source is used in multiple tags, their selections are now combined instead of being ignored.
+* `@inheritParams` no longer errors when a topic uses argument selection in more than one tag, e.g. `@inheritParams a x` followed by `@inheritParams b y` (#1879). If the same source is used in multiple tags, the union of their selections is now inherited instead of the selection being ignored, so an unfiltered tag inherits every parameter.
 * `@importFrom`, `@importClassesFrom`, and `@importMethodsFrom` now accept multi-line input, restoring the ability to spread imports across multiple lines for readability; continuation lines must use a hanging indent, so the first flush or blank line ends the tag and content after it (e.g. from a forgotten `@examples`) is no longer silently absorbed into the namespace (#1890).
 
 # roxygen2 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * The automatic usage for a data object that is conditional on the `LazyData` option in the `DESCRIPTION` (see below) now correctly detects all ways to specify a true value, e.g. also `yes`, `Yes` or `True` (@jranke, #1881).
 * `@import` now inserts the directive as is into `NAMESPACE` when it contains a comma, making it possible to use other forms like `@import rlang, except = ":="`.
 * `@importFrom` now generates a single multiline `importFrom()` directive per package instead of one directive per symbol. This fixes a performance issue with `loadNamespace()` for packages that import many symbols.
+* `@inheritParams` no longer errors when a topic uses argument selection in more than one tag, e.g. `@inheritParams a x` followed by `@inheritParams b y` (#1879). If the same source is used in multiple tags, their selections are now combined instead of being ignored.
 * `@importFrom`, `@importClassesFrom`, and `@importMethodsFrom` now accept multi-line input, restoring the ability to spread imports across multiple lines for readability; continuation lines must use a hanging indent, so the first flush or blank line ends the tag and content after it (e.g. from a forgotten `@examples`) is no longer silently absorbed into the namespace (#1890).
 
 # roxygen2 8.0.0

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -123,14 +123,9 @@ rd_section_inherit_params_args <- function(source, args) {
   check_character(args)
   stopifnot(length(source) == length(args))
 
-  keep <- nzchar(args)
-  if (!any(keep)) {
-    return(NULL)
-  }
-  rd_section(
-    "inherit_params_args",
-    list(source = source[keep], args = args[keep])
-  )
+  # Empty args are retained: an unfiltered tag inherits every parameter, even
+  # if another tag filters the same source.
+  rd_section("inherit_params_args", list(source = source, args = args))
 }
 
 #' @export
@@ -216,13 +211,14 @@ inherit_params <- function(topic, topics) {
 
     # Apply argument filter if specified via @inheritParams foo args
     params_args <- topic$get_value("inherit_params_args")
-    args_filter <- paste0(
-      params_args$args[params_args$source == inheritor],
-      collapse = " "
-    )
-    if (nzchar(args_filter)) {
+    args_filters <- params_args$args[params_args$source == inheritor]
+    # Each tag selects independently; a source used in multiple tags inherits
+    # the union of their selections, so an unfiltered tag inherits everything.
+    if (length(args_filters) > 0 && all(nzchar(args_filters))) {
       doc_args <- map_chr(inherited_params, "[[", "name")
-      selected <- select_args_text(doc_args, args_filter, topic_name = source)
+      selected <- unlist(lapply(args_filters, function(args_filter) {
+        select_args_text(doc_args, args_filter, topic_name = source)
+      }))
       inherited_params <- Filter(
         function(p) any(p$name %in% selected),
         inherited_params

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -119,13 +119,18 @@ merge.rd_section_inherit_dot_params <- function(x, y, ...) {
 }
 
 rd_section_inherit_params_args <- function(source, args) {
-  check_string(source)
-  check_string(args)
+  check_character(source)
+  check_character(args)
+  stopifnot(length(source) == length(args))
 
-  if (!nzchar(args)) {
+  keep <- nzchar(args)
+  if (!any(keep)) {
     return(NULL)
   }
-  rd_section("inherit_params_args", list(source = source, args = args))
+  rd_section(
+    "inherit_params_args",
+    list(source = source[keep], args = args[keep])
+  )
 }
 
 #' @export
@@ -211,8 +216,11 @@ inherit_params <- function(topic, topics) {
 
     # Apply argument filter if specified via @inheritParams foo args
     params_args <- topic$get_value("inherit_params_args")
-    args_filter <- params_args$args[params_args$source == inheritor]
-    if (length(args_filter) == 1 && args_filter != "") {
+    args_filter <- paste0(
+      params_args$args[params_args$source == inheritor],
+      collapse = " "
+    )
+    if (nzchar(args_filter)) {
       doc_args <- map_chr(inherited_params, "[[", "name")
       selected <- select_args_text(doc_args, args_filter, topic_name = source)
       inherited_params <- Filter(

--- a/tests/testthat/test-rd-inherit.R
+++ b/tests/testthat/test-rd-inherit.R
@@ -765,10 +765,13 @@ test_that("multiple @inheritParams can each filter args (#1879)", {
   expect_equal(params, c(x = "X", z = "Z"))
 })
 
-test_that("@inheritParams filters are combined for a repeated source", {
-  out <- roc_proc_text(
-    rd_roclet(),
-    "
+test_that("@inheritParams filters are unioned for a repeated source", {
+  filter <- function(...) {
+    tags <- paste0("    #' @inheritParams ", c(...), collapse = "\n")
+    out <- roc_proc_text(
+      rd_roclet(),
+      paste0(
+        "
     #' A.
     #'
     #' @param x X
@@ -778,14 +781,24 @@ test_that("@inheritParams filters are combined for a repeated source", {
 
     #' B
     #'
-    #' @inheritParams a x
-    #' @inheritParams a z
+",
+        tags,
+        "
     b <- function(x, y, z) {}
     "
-  )[[2]]
+      )
+    )[[2]]
+    out$get_value("param")
+  }
 
-  params <- out$get_value("param")
-  expect_equal(params, c(x = "X", z = "Z"))
+  expect_equal(filter("a x", "a z"), c(x = "X", z = "Z"))
+  expect_equal(filter("a x", "a -y"), c(x = "X", z = "Z"))
+  # Each tag selects independently, so the order of tags doesn't matter
+  expect_equal(filter("a -y", "a x"), c(x = "X", z = "Z"))
+  expect_equal(filter("a x", "a -x"), c(x = "X", y = "Y", z = "Z"))
+  # An unfiltered tag selects everything
+  expect_equal(filter("a x", "a"), c(x = "X", y = "Y", z = "Z"))
+  expect_equal(filter("a", "a x"), c(x = "X", y = "Y", z = "Z"))
 })
 
 test_that("@inheritParams without args still works", {

--- a/tests/testthat/test-rd-inherit.R
+++ b/tests/testthat/test-rd-inherit.R
@@ -737,6 +737,57 @@ test_that("@inheritParams filtering works with external packages", {
   expect_false("na.rm" %in% names(params))
 })
 
+test_that("multiple @inheritParams can each filter args (#1879)", {
+  out <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' A.
+    #'
+    #' @param x X
+    #' @param y Y
+    a <- function(x, y) {}
+
+    #' B.
+    #'
+    #' @param z Z
+    #' @param w W
+    b <- function(z, w) {}
+
+    #' C
+    #'
+    #' @inheritParams a x
+    #' @inheritParams b -w
+    c <- function(x, y, z, w) {}
+    "
+  )[[3]]
+
+  params <- out$get_value("param")
+  expect_equal(params, c(x = "X", z = "Z"))
+})
+
+test_that("@inheritParams filters are combined for a repeated source", {
+  out <- roc_proc_text(
+    rd_roclet(),
+    "
+    #' A.
+    #'
+    #' @param x X
+    #' @param y Y
+    #' @param z Z
+    a <- function(x, y, z) {}
+
+    #' B
+    #'
+    #' @inheritParams a x
+    #' @inheritParams a z
+    b <- function(x, y, z) {}
+    "
+  )[[2]]
+
+  params <- out$get_value("param")
+  expect_equal(params, c(x = "X", z = "Z"))
+})
+
 test_that("@inheritParams without args still works", {
   out <- roc_proc_text(
     rd_roclet(),


### PR DESCRIPTION
Merging two `inherit_params_args` sections concatenates their sources and args, but the constructor used `check_string()`, so a second filtered `@inheritParams` always errored. It is now vectorised, like `rd_section_inherit_dot_params()`.

The filter lookup also required exactly one match. Sources are deduplicated on merge, so repeating one (`@inheritParams a x` plus `@inheritParams a z`) gave a length-2 filter that was silently ignored; selections are now combined.

Fixes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)