### PR TITLE
Always migrate RoxygenNote to Config/roxygen2/version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # roxygen2 (development version)
 
+* The migration from `RoxygenNote` to `Config/roxygen2/version` now happens whenever it's needed, not just when the roxygen2 version has changed. This fixes two cases where the deprecated `RoxygenNote` field was left in `DESCRIPTION` forever: when a collaborator using roxygen2 7.x re-added it after the package had already been migrated, and when its value happened to match the installed version (#1876).
 * Markdown processing now handles multibyte characters inside Rd tags correctly; previously a tag like `\code{café}` would corrupt the markdown interpretation of the text that followed it.
 * Markdown warnings triggered by a `rd_family_title` prefix (e.g. for an unsupported level 1 heading) no longer error.
 * Markdown link targets and inherited Rd topics are now resolved with cached indexes provided by the new rdtools package, replacing repeated `help()` calls and roxygen2's own topic lookup and package-qualification code. This substantially speeds up packages with many cross-references, e.g. Rd generation for testthat is nearly twice as fast.

--- a/R/roxygenize-setup.R
+++ b/R/roxygenize-setup.R
@@ -59,21 +59,30 @@ update_roxygen_version <- function(path, cur_version = NULL) {
       x = "Installed {.pkg roxygen2} is older than the version used with this package",
       i = "You have {.val {cur}} but you need {.val {prev}}"
     ))
-  } else if (!identical(cur, prev)) {
-    if (!is.na(prev) && numeric_version(prev) <= "6.1.99") {
-      cli::cli_rule()
-      cli::cli_inform(c(
-        "Changes in {.pkg roxygen2} 7.0.0:",
-        "* `%` is now escaped automatically in Markdown mode.",
-        "Please carefully check .Rd files for changes"
-      ))
-      cli::cli_rule()
-    }
+    return(invisible())
+  }
 
+  if (
+    !identical(cur, prev) && !is.na(prev) && numeric_version(prev) <= "6.1.99"
+  ) {
+    cli::cli_rule()
+    cli::cli_inform(c(
+      "Changes in {.pkg roxygen2} 7.0.0:",
+      "* `%` is now escaped automatically in Markdown mode.",
+      "Please carefully check .Rd files for changes"
+    ))
+    cli::cli_rule()
+  }
+
+  # Check the fields individually, rather than relying on `prev`, since an
+  # older roxygen2 might have re-added `RoxygenNote` after migration (#1876)
+  if (!identical(trimws(desc_version(path)), cur)) {
     cli::cli_inform(c(
       i = "Setting {.field Config/roxygen2/version} to {.val {cur}}"
     ))
     desc::desc_set("Config/roxygen2/version" = cur, file = path)
+  }
+  if (desc::desc_has_fields("RoxygenNote", file = path)) {
     desc::desc_del("RoxygenNote", file = path)
   }
 }
@@ -96,9 +105,13 @@ first_time <- function(path) {
 }
 
 roxygen_version <- function(path = ".") {
-  version <- desc::desc_get("Config/roxygen2/version", file = path)[[1]]
+  version <- desc_version(path)
   if (is.na(version)) {
     version <- desc::desc_get("RoxygenNote", file = path)[[1]]
   }
   trimws(version)
+}
+
+desc_version <- function(path = ".") {
+  desc::desc_get("Config/roxygen2/version", file = path)[[1]]
 }

--- a/tests/testthat/_snaps/roxygenize-setup.md
+++ b/tests/testthat/_snaps/roxygenize-setup.md
@@ -50,3 +50,17 @@
     Output
       [1] FALSE
 
+# removes old RoxygenNote field even if already migrated (#1876)
+
+    Code
+      roxygen_setup(path, cur_version = "8.0.0")
+    Output
+      [1] FALSE
+
+# doesn't touch DESCRIPTION if already up to date
+
+    Code
+      roxygen_setup(path, cur_version = "8.0.0")
+    Output
+      [1] FALSE
+

--- a/tests/testthat/helper-test.R
+++ b/tests/testthat/helper-test.R
@@ -62,7 +62,7 @@ local_package_copy <- function(path, env = caller_env(), set_version = TRUE) {
   if (set_version) {
     desc::desc_set(
       file = pkg_path,
-      RoxygenNote = as.character(packageVersion("roxygen2"))
+      "Config/roxygen2/version" = as.character(packageVersion("roxygen2"))
     )
   }
 

--- a/tests/testthat/test-roxygenize-setup.R
+++ b/tests/testthat/test-roxygenize-setup.R
@@ -16,27 +16,31 @@ test_that("informs about initial setup", {
 
 test_that("warns about non UTF-8 encoding", {
   path <- local_package_copy(test_path("empty"))
-  desc::desc_set(file = path, Encoding = "latin1", RoxygenNote = "8.0.0")
+  desc::desc_set(
+    file = path,
+    Encoding = "latin1",
+    "Config/roxygen2/version" = "8.0.0"
+  )
 
   expect_snapshot(roxygen_setup(path, cur_version = "8.0.0"))
 })
 
 test_that("warns if roxygen version is too new", {
   path <- local_package_copy(test_path("empty"))
-  desc::desc_set(file = path, RoxygenNote = "10.0.0")
+  desc::desc_set(file = path, "Config/roxygen2/version" = "10.0.0")
 
   expect_snapshot(roxygen_setup(path, cur_version = "8.0.0"))
 })
 
 test_that("informs about major changes in 7.0.0", {
-  path <- local_package_copy(test_path("empty"))
+  path <- local_package_copy(test_path("empty"), set_version = FALSE)
   desc::desc_set(file = path, RoxygenNote = "5.0.0")
 
   expect_snapshot(roxygen_setup(path, cur_version = "8.0.0"))
 })
 
 test_that("removes old RoxygenNote field", {
-  path <- local_package_copy(test_path("empty"))
+  path <- local_package_copy(test_path("empty"), set_version = FALSE)
   desc::desc_set(file = path, RoxygenNote = "7.0.0")
 
   suppressMessages(roxygen_setup(path, cur_version = "8.0.0"))
@@ -44,4 +48,29 @@ test_that("removes old RoxygenNote field", {
   desc <- desc::desc(file = path)
   expect_false(desc$has_fields("RoxygenNote"))
   expect_equal(desc$get("Config/roxygen2/version")[[1]], "8.0.0")
+})
+
+test_that("removes old RoxygenNote field even if already migrated (#1876)", {
+  path <- local_package_copy(test_path("empty"))
+  desc::desc_set(
+    file = path,
+    "Config/roxygen2/version" = "8.0.0",
+    RoxygenNote = "7.3.3"
+  )
+
+  expect_snapshot(roxygen_setup(path, cur_version = "8.0.0"))
+
+  desc <- desc::desc(file = path)
+  expect_false(desc$has_fields("RoxygenNote"))
+  expect_equal(desc$get("Config/roxygen2/version")[[1]], "8.0.0")
+})
+
+test_that("doesn't touch DESCRIPTION if already up to date", {
+  path <- local_package_copy(test_path("empty"))
+  desc::desc_set(file = path, "Config/roxygen2/version" = "8.0.0")
+
+  desc_path <- file.path(path, "DESCRIPTION")
+  before <- file.mtime(desc_path)
+  expect_snapshot(roxygen_setup(path, cur_version = "8.0.0"))
+  expect_equal(file.mtime(desc_path), before)
 })


### PR DESCRIPTION
Fixes #1876.

`update_roxygen_version()` did all its work — including deleting `RoxygenNote` — inside an `else if (!identical(cur, prev))` branch. Since `roxygen_version()` prefers `Config/roxygen2/version`, the migration was skipped whenever that field already matched the installed version. So if a collaborator on roxygen2 7.x re-added `RoxygenNote`, it stayed in `DESCRIPTION` forever.

Now the migration decides from the actual `DESCRIPTION` fields rather than from `prev`, still guarding both writes so `DESCRIPTION` isn't rewritten when nothing needs to change. This also fixes packages with only `RoxygenNote: <installed version>` and no `Config` field, which were never migrated at all.

`local_package_copy()` now stamps `Config/roxygen2/version` instead of the deprecated field, so the fixtures represent a post-8.0.0 package and don't all emit a migration message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)