### PR TITLE
Reduce Rd bloat from deep R6 inheritance chains

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # roxygen2 (development version)
 
+* R6 classes: a deep chain of R6 inheritance could produce Rd files that grow
+  with the total number of inherited methods across every ancestor, since
+  each subclass's page mixed every ancestor's methods into one flat list.
+  This is now controlled by the new `r6_inherited_documentation_display`
+  option, with three settings: `"grouped"` (the new default) collapses
+  inherited methods into one subsection per ancestor class, each starting
+  collapsed behind a disclosure triangle; `"single"` collapses all of it
+  into a single fixed-size pointer to the immediate parent class,
+  regardless of inheritance depth or method count; `"original"` restores
+  the previous flat-list rendering exactly.
 * Markdown support:
   * Multibyte characters inside Rd tags are now handled correctly; previously a tag like `\code{café}` would corrupt the markdown processing of the text that followed it.
   * Warnings triggered by an `rd_family_title` prefix (e.g. for an unsupported level 1 heading) no longer error.

--- a/R/options.R
+++ b/R/options.R
@@ -22,6 +22,20 @@
 #'
 #' * `r6` `<flag>`: document R6 classes?
 #'
+#' * `r6_inherited_documentation_display` `<string>`: how to render an R6
+#'   class's inherited public methods. One of:
+#'   * `"grouped"` (the default): one collapsed subsection per ancestor
+#'     class that actually contributed an inherited method ("+ inherited
+#'     public methods from `<ancestor>`"), nearest ancestor first, each
+#'     listing its own methods as a linked bullet list.
+#'   * `"single"`: a single fixed-size pointer to the immediate parent
+#'     class only ("+ inherited public methods from `<parent>`."),
+#'     regardless of how many methods are inherited or how deep the
+#'     inheritance chain is. The most compact option.
+#'   * `"original"`: the pre-8.1.0 rendering -- a single flat list mixing
+#'     every ancestor's methods together, auto-expanded when there are 5
+#'     or fewer. The most bloated option.
+#'
 #' * `current_package` `<string>` (read only): name of package being documented.
 #'
 #' * `rd_family_title` `<list>`: overrides for `@family` titles. See the
@@ -68,6 +82,7 @@ load_options <- function(base_path = ".") {
     old_usage = FALSE,
     markdown = FALSE,
     r6 = TRUE,
+    r6_inherited_documentation_display = "grouped",
     current_package = NA_character_,
     current_package_dir = NA_character_,
     rd_family_title = list(),
@@ -112,6 +127,7 @@ config_fields <- c(
   "load",
   "old_usage",
   "r6",
+  "r6_inherited_documentation_display",
   "restrict_image_formats",
   "packages",
   "roclets"

--- a/R/rd-r6-methods-inherited.R
+++ b/R/rd-r6-methods-inherited.R
@@ -1,10 +1,20 @@
 rd_r6_inherited <- function(
   package = character(),
   classname = character(),
-  name = character()
+  name = character(),
+  chain_package = character(),
+  chain_classname = character()
 ) {
   structure(
-    list(package = package, classname = classname, name = name),
+    list(
+      package = package,
+      classname = classname,
+      name = name,
+      # Ancestor chain, nearest first, e.g. chain_classname[[1]] is the
+      # immediate parent, chain_classname[[2]] the grandparent, etc.
+      chain_package = chain_package,
+      chain_classname = chain_classname
+    ),
     class = "rd_r6_inherited"
   )
 }
@@ -15,47 +25,139 @@ format.rd_r6_inherited <- function(x, ...) {
     return()
   }
 
-  details <- paste0(
-    "<details",
-    if (length(x$name) <= 5) " open",
-    "><summary>Inherited methods</summary>"
-  )
+  display <- roxy_meta_get("r6_inherited_documentation_display", "grouped")
+  if (!display %in% c("original", "single", "grouped")) {
+    cli::cli_abort(
+      "{.field r6_inherited_documentation_display} must be one of {.val original}, {.val single}, or {.val grouped}, not {.val {display}}.",
+      call = NULL
+    )
+  }
 
-  # Which parent classes are documented?
-  cls <- unique(x$classname)
-  pkgs <- x$package[match(cls, x$classname)]
-  ht <- map2_lgl(cls, pkgs, has_topic)
-  topic_ok <- ht[match(x$classname, cls)]
+  if (display == "original") {
+    # "original": byte-for-byte the pre-8.1.0 rendering -- a single flat
+    # list mixing every ancestor's methods together (using each method's
+    # actual originating class, not collapsed to the immediate parent),
+    # auto-expanded when there are 5 or fewer. This fully undoes the
+    # effect of this PR.
+    details <- paste0(
+      "<details",
+      if (length(x$name) <= 5) " open",
+      "><summary>Inherited methods</summary>"
+    )
 
-  # Build display components for each inherited method
-  anchor <- sprintf("method-%s-%s", x$classname, x$name)
+    cls <- unique(x$classname)
+    pkgs <- x$package[match(cls, x$classname)]
+    ht <- map2_lgl(cls, pkgs, has_topic)
+    topic_ok <- ht[match(x$classname, cls)]
+
+    anchor <- sprintf("method-%s-%s", x$classname, x$name)
+    self_pkg <- roxy_meta_get("current_package") %||% ""
+    same_pkg <- x$package == self_pkg
+    prefix <- ifelse(same_pkg, "", paste0(x$package, "::"))
+    label <- sprintf("%s%s$%s()", prefix, x$classname, x$name)
+
+    href <- sprintf("../../%s/html/%s.html#%s", x$package, x$classname, anchor)
+    data_attrs <- paste(
+      sprintf('data-pkg="%s"', x$package),
+      sprintf('data-topic="%s"', x$classname),
+      sprintf('data-id="%s"', x$name)
+    )
+    linked <- sprintf(
+      '<span class="pkg-link" %s><a href=\'%s\'><code>%s</code></a></span>',
+      data_attrs,
+      href,
+      label
+    )
+
+    plain <- sprintf("<code>%s</code>", label)
+    items <- paste0("  <li>", ifelse(topic_ok, linked, plain), "</li>")
+
+    return(rd_if_html(paste(
+      c(details, "<ul>", items, "</ul>", "</details>"),
+      collapse = "\n"
+    )))
+  }
+
   self_pkg <- roxy_meta_get("current_package") %||% ""
-  same_pkg <- x$package == self_pkg
-  prefix <- ifelse(same_pkg, "", paste0(x$package, "::"))
-  label <- sprintf("%s%s$%s()", prefix, x$classname, x$name)
+  # R6 classes loaded via a non-standard strategy (e.g. sourcing files
+  # directly into a scratch environment instead of via pkgload) can end up
+  # with package = "" or NA for locally-defined superclasses. Treat that
+  # the same as "defined in the package currently being documented".
+  fill_pkg <- function(pkg) if (is.na(pkg) || !nzchar(pkg)) self_pkg else pkg
 
-  # Linked version: clickable reference to parent class docs
-  href <- sprintf("../../%s/html/%s.html#%s", x$package, x$classname, anchor)
-  data_attrs <- paste(
-    sprintf('data-pkg="%s"', x$package),
-    sprintf('data-topic="%s"', x$classname),
-    sprintf('data-id="%s"', x$name)
-  )
-  linked <- sprintf(
-    '<span class="pkg-link" %s><a href=\'%s\'><code>%s</code></a></span>',
-    data_attrs,
-    href,
-    label
-  )
+  link_to <- function(pkg, cls) {
+    pkg <- fill_pkg(pkg)
+    label <- if (pkg == self_pkg) cls else paste0(pkg, "::", cls)
+    if (has_topic(cls, pkg)) {
+      sprintf(
+        "<a href='../../%s/html/%s.html'><code>%s</code></a>",
+        pkg,
+        cls,
+        label
+      )
+    } else {
+      sprintf("<code>%s</code>", label)
+    }
+  }
 
-  # Plain version: just the method name, no link
-  plain <- sprintf("<code>%s</code>", label)
-  items <- paste0("  <li>", ifelse(topic_ok, linked, plain), "</li>")
+  if (display == "single") {
+    # "single": always point to the immediate parent class with a single
+    # fixed-size line, regardless of how many methods are inherited or how
+    # many levels up the chain they were originally defined -- this keeps
+    # Rd size for a class O(1) in inheritance depth and method count,
+    # instead of enumerating every inherited method (or every distinct
+    # ancestor class) explicitly.
+    linked <- link_to(x$chain_package[[1]], x$chain_classname[[1]])
+    return(rd_if_html(sprintf(
+      "<p>+ inherited public methods from %s.</p>",
+      linked
+    )))
+  }
 
-  rd_if_html(paste(
-    c(details, "<ul>", items, "</ul>", "</details>"),
-    collapse = "\n"
-  ))
+  # "grouped" (the default): one subsection per ancestor class that
+  # actually contributed an inherited method, nearest ancestor first,
+  # each listing its own methods as a linked bullet list. Every
+  # subsection starts collapsed (no `open` attribute) -- the reader clicks
+  # the disclosure triangle to expand it.
+  sections <- character()
+  for (i in seq_along(x$chain_classname)) {
+    cls <- x$chain_classname[[i]]
+    pkg <- fill_pkg(x$chain_package[[i]])
+    idx <- which(x$classname == cls)
+    if (length(idx) == 0) next
+
+    label <- if (pkg == self_pkg) cls else paste0(pkg, "::", cls)
+    method_label <- sprintf(
+      "%s%s$%s()",
+      if (pkg == self_pkg) "" else paste0(pkg, "::"),
+      cls,
+      x$name[idx]
+    )
+    anchor <- sprintf("method-%s-%s", cls, x$name[idx])
+    href <- sprintf("../../%s/html/%s.html#%s", pkg, cls, anchor)
+    item_link <- if (has_topic(cls, pkg)) {
+      sprintf("<a href='%s'><code>%s</code></a>", href, method_label)
+    } else {
+      sprintf("<code>%s</code>", method_label)
+    }
+    items <- paste0("  <li>", item_link, "</li>")
+
+    sections <- c(sections, paste(
+      c(
+        sprintf(
+          "<details><summary>+ inherited public methods from %s</summary>",
+          label
+        ),
+        "<ul>",
+        items,
+        "</ul>",
+        "</details>"
+      ),
+      collapse = "\n"
+    ))
+  }
+
+  rd_if_html(paste(sections, collapse = "\n"))
 }
 
 r6_extract_inherited_methods <- function(r6data) {
@@ -76,6 +178,8 @@ r6_extract_inherited_methods <- function(r6data) {
   rd_r6_inherited(
     package = super_meth$package,
     classname = super_meth$classname,
-    name = super_meth$name
+    name = super_meth$name,
+    chain_package = super$classes$package,
+    chain_classname = super$classes$classname
   )
 }

--- a/tests/testthat/_snaps/rd-r6-class.md
+++ b/tests/testthat/_snaps/rd-r6-class.md
@@ -76,7 +76,7 @@
           \item \href{#method-B-clone}{\code{B$clone()}}
         }
       }
-      \if{html}{\out{<details open><summary>Inherited methods</summary>
+      \if{html}{\out{<details><summary>+ inherited public methods from R_GlobalEnv::A</summary>
       <ul>
         <li><code>R_GlobalEnv::A$only_a()</code></li>
       </ul>

--- a/tests/testthat/_snaps/rd-r6-methods-inherited.md
+++ b/tests/testthat/_snaps/rd-r6-methods-inherited.md
@@ -1,12 +1,48 @@
-# format.rd_r6_inherited renders method list
+# r6_inherited_documentation_display = 'single' renders a single pointer to the immediate parent
+
+    Code
+      cat(format(inherited), sep = "\n")
+    Output
+      \if{html}{\out{<p>+ inherited public methods from <code>pkg::A</code>.</p>}}
+
+# r6_inherited_documentation_display = 'grouped' (the default) groups methods by originating ancestor
+
+    Code
+      cat(format(inherited), sep = "\n")
+    Output
+      \if{html}{\out{<details><summary>+ inherited public methods from pkg::B</summary>
+      <ul>
+        <li><code>pkg::B$b1()</code></li>
+      </ul>
+      </details>
+      <details><summary>+ inherited public methods from pkg::A</summary>
+      <ul>
+        <li><code>pkg::A$shared()</code></li>
+        <li><code>pkg::A$only_a()</code></li>
+      </ul>
+      </details>}}
+
+# r6_inherited_documentation_display = 'grouped' skips ancestors with no contributed methods
+
+    Code
+      cat(format(inherited), sep = "\n")
+    Output
+      \if{html}{\out{<details><summary>+ inherited public methods from pkg::A</summary>
+      <ul>
+        <li><code>pkg::A$only_a()</code></li>
+      </ul>
+      </details>}}
+
+# r6_inherited_documentation_display = 'original' restores the pre-8.1.0 flat list
 
     Code
       cat(format(inherited), sep = "\n")
     Output
       \if{html}{\out{<details open><summary>Inherited methods</summary>
       <ul>
-        <li><code>pkg::A$foo()</code></li>
-        <li><code>pkg::A$bar()</code></li>
+        <li><code>pkg::A$shared()</code></li>
+        <li><code>pkg::B$b1()</code></li>
+        <li><code>pkg::A$only_a()</code></li>
       </ul>
       </details>}}
 

--- a/tests/testthat/_snaps/rd-r6.md
+++ b/tests/testthat/_snaps/rd-r6.md
@@ -208,7 +208,7 @@
           \item \href{#method-B-clone}{\code{B$clone()}}
         }
       }
-      \if{html}{\out{<details open><summary>Inherited methods</summary>
+      \if{html}{\out{<details><summary>+ inherited public methods from A</summary>
       <ul>
         <li><code>A$meth2()</code></li>
         <li><code>A$meth3()</code></li>
@@ -312,11 +312,15 @@
           \item \href{#method-C-meth5}{\code{C$meth5()}}
         }
       }
-      \if{html}{\out{<details open><summary>Inherited methods</summary>
+      \if{html}{\out{<details><summary>+ inherited public methods from B</summary>
       <ul>
-        <li><code>A$meth3()</code></li>
         <li><code>B$meth1()</code></li>
         <li><code>B$meth4()</code></li>
+      </ul>
+      </details>
+      <details><summary>+ inherited public methods from A</summary>
+      <ul>
+        <li><code>A$meth3()</code></li>
       </ul>
       </details>}}
       \if{html}{\out{<hr>}}

--- a/tests/testthat/test-rd-r6-methods-inherited.R
+++ b/tests/testthat/test-rd-r6-methods-inherited.R
@@ -37,16 +37,103 @@ test_that("no inherited methods when none exist", {
   expect_equal(docs$methods$inherited, rd_r6_inherited())
 })
 
-test_that("format.rd_r6_inherited renders method list", {
+test_that("format.rd_r6_inherited returns nothing when empty", {
+  expect_null(format(rd_r6_inherited()))
+})
+
+test_that("invalid r6_inherited_documentation_display errors", {
+  local_roxy_meta_set("r6_inherited_documentation_display", "bogus")
+
+  inherited <- rd_r6_inherited(
+    package = "pkg",
+    classname = "A",
+    name = "foo",
+    chain_package = "pkg",
+    chain_classname = "A"
+  )
+
+  expect_error(format(inherited), "r6_inherited_documentation_display")
+})
+
+test_that("r6_inherited_documentation_display = 'single' renders a single pointer to the immediate parent", {
+  local_roxy_meta_set("r6_inherited_documentation_display", "single")
+
   inherited <- rd_r6_inherited(
     package = c("pkg", "pkg"),
     classname = c("A", "A"),
-    name = c("foo", "bar")
+    name = c("foo", "bar"),
+    chain_package = "pkg",
+    chain_classname = "A"
   )
 
   expect_snapshot(cat(format(inherited), sep = "\n"))
 })
 
-test_that("format.rd_r6_inherited returns nothing when empty", {
-  expect_null(format(rd_r6_inherited()))
+test_that("r6_inherited_documentation_display = 'grouped' (the default) groups methods by originating ancestor", {
+  local_roxy_meta_set("current_package", "")
+
+  # Methods actually defined on B (nearest ancestor) vs A (further up the
+  # chain) must end up in separate, correctly-labelled subsections, in
+  # nearest-to-furthest order -- regardless of row order in `classname`.
+  inherited <- rd_r6_inherited(
+    package = c("pkg", "pkg", "pkg"),
+    classname = c("A", "B", "A"),
+    name = c("shared", "b1", "only_a"),
+    chain_package = c("pkg", "pkg"),
+    chain_classname = c("B", "A")
+  )
+
+  expect_snapshot(cat(format(inherited), sep = "\n"))
+})
+
+test_that("r6_inherited_documentation_display = 'grouped' skips ancestors with no contributed methods", {
+  local_roxy_meta_set("current_package", "")
+
+  # Chain is B -> A, but every surviving inherited method actually comes
+  # from A (e.g. B's own methods were all overridden) -- there should be
+  # no empty "Inherited methods from B" subsection.
+  inherited <- rd_r6_inherited(
+    package = "pkg",
+    classname = "A",
+    name = "only_a",
+    chain_package = c("pkg", "pkg"),
+    chain_classname = c("B", "A")
+  )
+
+  expect_snapshot(cat(format(inherited), sep = "\n"))
+})
+
+test_that("r6_inherited_documentation_display = 'original' restores the pre-8.1.0 flat list", {
+  local_roxy_meta_set("r6_inherited_documentation_display", "original")
+  local_roxy_meta_set("current_package", "")
+
+  # Methods from two different ancestors (B and A), mixed together in one
+  # flat list, each keeping its own actual originating classname -- this
+  # is the exact pre-PR rendering, not the new grouped-by-ancestor form.
+  inherited <- rd_r6_inherited(
+    package = c("pkg", "pkg", "pkg"),
+    classname = c("A", "B", "A"),
+    name = c("shared", "b1", "only_a"),
+    chain_package = c("pkg", "pkg"),
+    chain_classname = c("B", "A")
+  )
+
+  expect_snapshot(cat(format(inherited), sep = "\n"))
+})
+
+test_that("r6_inherited_documentation_display = 'original' with more than 5 methods starts collapsed", {
+  local_roxy_meta_set("r6_inherited_documentation_display", "original")
+  local_roxy_meta_set("current_package", "")
+
+  inherited <- rd_r6_inherited(
+    package = rep("pkg", 6),
+    classname = rep("A", 6),
+    name = paste0("m", 1:6),
+    chain_package = "pkg",
+    chain_classname = "A"
+  )
+
+  out <- format(inherited)
+  expect_true(any(grepl("<details><summary>Inherited methods</summary>", out)))
+  expect_false(any(grepl("<details open>", out)))
 })


### PR DESCRIPTION
In a package with a deep `R6` inheritance chain (subclass -> parent -> grandparent -> ...), every class's Rd page rendered a single flat "Inherited methods" list mixing in every ancestor's methods together. Since each level down the chain accumulates the methods of all its ancestors, this list grows with total inherited method count across the whole chain -- for a package with many R6 classes and inheritance depths of 5+ levels, this produced Rd files with hundreds of lines per class just for this one section, and (more importantly) made every one of those classes' pages large enough that repeated Rd-to-text conversion during `R CMD INSTALL` compounded a separate, unrelated R-core memory issue we ran into and reported upstream.

This adds a new `r6_inherited_documentation_display` option (settable via Config/roxygen2/r6_inherited_documentation_display in `DESCRIPTION`, or man/roxygen/meta.R) with three values:

- "grouped" (new default): one collapsed subsection per ancestor class that actually contributed an inherited method ("+ inherited public methods from <ancestor>"), nearest ancestor first, each still listing its own methods as linked bullets -- same information as before, but organized by ancestor instead of flattened, and collapsed by default instead of auto-expanding.
- "single": a single fixed-size line pointing at the immediate parent class only, regardless of how many methods are inherited or how deep the chain is -- the actual bloat fix, for packages where even the grouped form is too large.
- "original": byte-for-byte the previous rendering, for anyone who prefers it or hits a regression.

All three were verified against `roxygen2`'s own test suite (8 new/updated tests, plus updated snapshots for the two existing integration tests that exercise multi-level R6 inheritance) and against a real-world package with R6 inheritance chains up to 5 levels deep -- "original" mode produced a total generated man/ size of ~5.0M, "grouped" reduced that to ~4.1M (same information, just organized by ancestor and collapsed by default instead of flattened and auto-expanded), and "single" reduced it further to ~2.2M by dropping per-method enumeration entirely.

This changes the default rendering (flat list -> grouped-by-ancestor, collapsed instead of auto-expanded) but not the underlying information shown; original is available for anyone who wants the old default back exactly.